### PR TITLE
Add Dan Anderson as a sawtooth-website maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,6 +4,7 @@
 | Andi Gunderson | agunde406 | agunde |
 | Anne Chenette | chenette | achenette |
 | Boyd Johnson | boydjohnson | boydjohnson |
+| Dan Anderson | danintel | danintel |
 | Dan Middleton | dcmiddle | Dan |
 | Darian Plumb | dplumb94 | dplumb |
 | James Mitchell | jsmitchell | jsmitchell |


### PR DESCRIPTION
I am proposing Dan Anderson as a maintainer on this repository because of Dan's work helping the community (via RocketChat, for example) as well as maintaining a Sawtooth FAQ (https://github.com/danintel/sawtooth-faq/). The FAQ will be integrated into this repository soon, which is a significant contribution.