### PR TITLE
Add Build-Only option

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,3 +32,5 @@ services:
       - 8000:80
     volumes:
       - $PWD/generator:/srv/jekyll
+    environment:
+      - BUILDONLY=${BUILDONLY}

--- a/generator/entrypoint-web.sh
+++ b/generator/entrypoint-web.sh
@@ -75,7 +75,7 @@ if (shopt -s nullglob dotglob; f=(/srv/jekyll/_site/*); ((${#f[@]}))); then
 
     info "Copying build to container"
     cp -rf ./archive/htdocs/* /usr/local/apache2/htdocs/
-    /usr/local/apache2/bin/httpd -DFOREGROUND
+    echo "$BUILDONLY" | grep -qEix 'yes|true|1|y' || /usr/local/apache2/bin/httpd -DFOREGROUND
 else
     rm /srv/jekyll/*.complete
     info "Site was not built"


### PR DESCRIPTION
Add environment option to stop after generating the site. For automated deployment.

E.g.: `BUILDONLY=true docker-compose up`

Signed-off-by: Sutrannu <bbetts@bitwise.io>