### PR TITLE
Add Sawtooth PBFT to mininav; put in alph order

### DIFF
--- a/generator/source/docs/docs.rst
+++ b/generator/source/docs/docs.rst
@@ -15,6 +15,7 @@ Hyperledger Sawtooth Documentation
 .. class:: mininav
 
 `Sawtooth Core`_
+`Sawtooth PBFT`_
 `Sawtooth Sabre`_
 `Sawtooth Seth`_
 `Sawtooth Supply Chain`_
@@ -30,6 +31,11 @@ Sawtooth Core
 -  `Nightly master <core/nightly/master/>`__
 -  `Nightly 1-1 <core/nightly/1-1/>`__
 
+Sawtooth PBFT
+---------------------
+
+-  `Nightly master <pbft/nightly/master/>`__
+
 Sawtooth Sabre
 --------------
 
@@ -44,9 +50,4 @@ Sawtooth Supply Chain
 ---------------------
 
 -  `Nightly master <supply-chain/nightly/master/>`__
-
-Sawtooth PBFT
----------------------
-
--  `Nightly master <pbft/nightly/master/>`__
 


### PR DESCRIPTION
A previous PR added Sawtooth PBFT to the end of the page, but it wasn't in the top navigation.

This PR fixes that omission. It also moves the Sawtooth PBFT section up so that the page continues to list Sawtooth products in alphabetical order.

Signed-off-by: Anne Chenette <chenette@bitwise.io>