### PR TITLE
Update PBFT and Raft info

### DIFF
--- a/generator/source/faq/consensus.rst
+++ b/generator/source/faq/consensus.rst
@@ -21,6 +21,8 @@ What consensus algorithms does Sawtooth support?
 ------------------------------------------------
 Devmode (name "Devmode", version 0.1)
     Only suitable for testing TPs with single validator deployments. Uses a simplified random-leader algorithm for development and testing. Not for production use
+PBFT (name "pbft", version 0.1)
+    Leader-based, non-forking consensus algorithm with finality that provides Byzantine Fault Tolerance (BFT). Ideal for smaller, consortium-style networks that do not require open membership.
 PoET CFT (name "PoET", version 0.1)
     Also known as PoET Simulator. PoET with a simulated SGX environment. Provides CFT similar to some other blockchains. Requires poet-validator-registry TP. Runs on any processor (does not require Intel or SGX). Has Crash Fault Tolerance (CFT), but is not Byzantine Fault Tolerant (BFT)
 PoET SGX (name "PoET", version 0.1)
@@ -31,7 +33,7 @@ Raft (name "raft", version 0.1)
 Will Sawtooth support more consensus algorithms in the future?
 --------------------------------------------------------------
 
-Yes. With pluggable consensus, the idea is to have a meaningful set of consensus algorithms so the "best fit" can be applied to an application's use case. Raft is a recent addition--still being stabilized. There is a PBFT prototype in the works. Others are being planned.
+Yes. With pluggable consensus, the idea is to have a meaningful set of consensus algorithms so the "best fit" can be applied to an application's use case. Raft is a recent addition--still being stabilized. Others are being planned.
 
 REMME.io has independently implemented Algorand Byzantine Agreement on Sawtooth.
 

--- a/generator/source/faq/consensus.rst
+++ b/generator/source/faq/consensus.rst
@@ -25,7 +25,7 @@ PoET CFT (name "PoET", version 0.1)
     Also known as PoET Simulator. PoET with a simulated SGX environment. Provides CFT similar to some other blockchains. Requires poet-validator-registry TP. Runs on any processor (does not require Intel or SGX). Has Crash Fault Tolerance (CFT), but is not Byzantine Fault Tolerant (BFT)
 PoET SGX (name "PoET", version 0.1)
     Takes advantage of SGX in order to provide consensus with Byzantine Fault Tolerance (BFT), like PoW algorithms have, but at very low CPU usage. PoET SGX is the only algorithm that has hardware requirements (a processor supporting SGX). Currently supported in Sawtooth 1.0 only.
-Raft (name "sawtooth-raft-engine", version 0.1.0)
+Raft (name "raft", version 0.1)
     Consensus algorithm that elects a leader for a term of arbitrary time. Leader replaced if it times-out. Raft is faster than PoET, but is CFT, not BFT. Also Raft does not fork. For Sawtooth Raft is new and still being stabilized.
 
 Will Sawtooth support more consensus algorithms in the future?

--- a/generator/source/faq/settings.rst
+++ b/generator/source/faq/settings.rst
@@ -69,13 +69,17 @@ sawtooth.consensus.pbft.exponential_retry_base
 sawtooth.consensus.pbft.exponential_retry_max
     Maximum time for retrying with exponential backoff.
     Optional, default 60s
-sawtooth.consensus.pbft.faulty_primary_timeout
+sawtooth.consensus.pbft.idle_timeout
     How long to wait for the next (BlockNew + PrePrepare) before determining
-    primary is faulty. Should be > block_duration.
+    primary is faulty. Must be longer than block_duration.
+    Optional, default 30s
+sawtooth.consensus.pbft.commit_timeout
+    How long to wait (after Pre-Preparing) for the node to commit the block
+    before starting a view change
     Optional, default 30s
 sawtooth.consensus.pbft.view_change_duration
-    If the node starts a change to view (v + 2),
-    the timeout will be (2 * view_change_duration)
+    If a node on view v starts a change to view (v + n), the timeout before
+    starting a new change to view (v + n + 1) will be (n * view_change_duration)
     Optional, default 5s
 sawtooth.consensus.pbft.forced_view_change_period
     How many blocks to commit before forcing a view change for fairness
@@ -84,7 +88,8 @@ sawtooth.consensus.pbft.message_timeout
     How long to wait for updates from the Consensus API.
     Optional, default 10 ms.
 sawtooth.consensus.pbft.max_log_size
-    Log size. Optional, default 1000 messages
+    How large the PBFT message log is allowed to get.
+    Optional, default 1000 messages
 
 sawtooth.consensus.raft.election_tick
     RAFT consensus election tick, in seconds. E.g., 1500

--- a/generator/source/faq/settings.rst
+++ b/generator/source/faq/settings.rst
@@ -41,9 +41,9 @@ sawtooth.config.authorization_type
     Example setting--never used.  To set authorization type, use command line option ``sawtooth-validator --network-auth {trust|challenge}``
 
 sawtooth.consensus.algorithm.name
-    Pluggable consensus algorithm name. These include ``PoET``, ``Devmode``, ``sawtooth-raft-engine``, and ``sawtooth-pbft``.  The default is ``devmode`` for Sawtooth 1.1 or earlier, with no default for the (unreleased) nightly build.
+    Pluggable consensus algorithm name. These include ``PoET``, ``Devmode``, ``raft``, and ``pbft``.  The default is ``devmode`` for Sawtooth 1.1 or earlier, with no default for the (unreleased) nightly build.
 sawtooth.consensus.algorithm.version
-    Consensus algorithm version. Currently 0.1 for PoET, Devmode, and sawtooth-pbft, and 0.1.0 for sawtooth-raft-engine.
+    Consensus algorithm version. Currently 0.1 for PoET, Devmode, PBFT, and Raft.
 sawtooth.consensus.block_validation_rules
     Lists validation rules to use in deciding what blocks to add to the blockchain.
     See https://sawtooth.hyperledger.org/docs/core/nightly/master/architecture/injecting_batches_block_validation_rules.html


### PR DESCRIPTION
Updates the values of the algorithm name and version settings for the
PBFT and Raft consensus engines to match the new values from the
corresponding PRs against the engine repos
(hyperledger/sawtooth-pbft#118,
hyperledger/sawtooth-raft#59)

Also updates FAQs to match status of PBFT.