### PR TITLE
Retire Inactive Maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @agunde406 @aludvik @boydjohnson @chenette @danintel @dcmiddle @dplumb94 @ineffectualproperty @jsmitchell @peterschwarz @rbuysse @vaporos
+*       @agunde406 @chenette @danintel @dcmiddle @dplumb94 @ineffectualproperty @jsmitchell @peterschwarz @rbuysse @vaporos

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,9 +1,10 @@
+## Maintainers
+
+### Active Maintainers
 | Name | GitHub | RocketChat |
 | --- | --- | --- |
-| Adam Ludvik | aludvik | adamludvik |
 | Andi Gunderson | agunde406 | agunde |
 | Anne Chenette | chenette | achenette |
-| Boyd Johnson | boydjohnson | boydjohnson |
 | Dan Anderson | danintel | danintel |
 | Dan Middleton | dcmiddle | Dan |
 | Darian Plumb | dplumb94 | dplumb |
@@ -12,3 +13,9 @@
 | Peter Schwarz | peterschwarz | pschwarz |
 | Ryan Beck-Buysse | rbuysse | rbuysse |
 | Shawn Amundson | vaporos | amundson |
+
+### Retired Maintainers
+| Name | GitHub | RocketChat |
+| --- | --- | --- |
+| Adam Ludvik | aludvik | adamludvik |
+| Boyd Johnson | boydjohnson | boydjohnson |


### PR DESCRIPTION
The following maintainers have asked to be retired:

Adam Ludvik and Boyd Johnson

As described in the Sawtooth Governance RFC changes to maintainers must be approved unanimously by the current group of maintainers.