### PR TITLE
added faq for sawtooth-default-poet.yaml setup

### DIFF
--- a/generator/source/faq/docker.rst
+++ b/generator/source/faq/docker.rst
@@ -221,6 +221,20 @@ I get this error running Docker: ``ERROR: manifest for hyperledger/sawtooth-vali
 -----------------------------------------------------------------------------------------------------
 You are following instructions for the unreleased Sawtooth ``nightly`` build. There are no Docker images for the nightly build. Instead use the ``latest`` build documentation at https://sawtooth.hyperledger.org/docs/core/releases/latest/app_developers_guide.html
 
+Why doesn't sawtooth-default-poet.yaml start the network successfully on subsequent runs ?
+------------------------------------------------------------------------------------------
+
+The root cause is the stale volume mounted, these are mounted for storing
+sawtooth keys in order to share between the containers. If you observe the error
+in subsequent runs that means these mounted volumes are left behind. The command
+"docker-compose down" does not remove the stale volumes mounted. To solve the
+problem, you can prune the volume as well and not just down the containers.
+For example the following removes containers and volumes
+
+::
+   
+   docker-compose down -v
+
 .. class:: mininav
 
 PREVIOUS_ FAQ_ NEXT_


### PR DESCRIPTION
The docker-compose file - sawtooth-default-poet.yaml in the
repository is not able to bring up a network always.
Few validators are left out(unregistered) at times. Subsequent
transaction submission leads to invalid blocks in validity
check at the PoET engine -

Signed-off-by: raneja14 <raneja7@gmail.com>