### PR TITLE
Pinning Docutils to 0.15.1

### DIFF
--- a/generator/Dockerfile
+++ b/generator/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update -q && \
     python-pip \
     unzip && \
     rm -rf /var/lib/apt/lists/* && \
-    pip install docutils pygments && \
+    pip install docutils==0.15.1 pygments && \
     gem install jekyll bundler
 
 COPY Gemfile .


### PR DESCRIPTION
This prevents pip from trying to compile the .zip package and instead
install the binary wheel.

Signed-off-by: Richard Berg <rberg@bitwise.io>