### PR TITLE
Tidy the Sawtooth website

### DIFF
--- a/generator/_config.yml
+++ b/generator/_config.yml
@@ -12,6 +12,7 @@ theme_settings:
   avatar: avatar.png
   gravatar: # Email MD5 hash
   description: "An enterprise-grade solution for distributed ledgers." # used by search engines
+  site_navigation_sort: order
 
   # Header and footer text
   header_text: >

--- a/generator/_config.yml
+++ b/generator/_config.yml
@@ -19,22 +19,42 @@ theme_settings:
      <h1>Sawtooth</h1>
   header_text_feature_image: ../examples/img/hero-bg.jpg
   footer_text: >
-    <h2>Sawtooth</h2>
+    <p style="font-size: 1.5em;">
+      Hyperledger Sawtooth
+    </p>
     <p>
+      <a href="/" title="Home"><span class="links">Home</span></a>
+      &bull;
+      <a href="/about/" title="About Sawtooth"><span class="links">About</span></a>
+      &bull;
+      <a href="/release/" title="Releases"><span class="links">Releases</span></a>
+      &bull;
+      <a href="/docs/" title="Documentation"><span class="links">Docs</span></a>
+      &bull;
+      <a href="/faq/" title="FAQ"><span class="links">FAQ</span></a>
+      &bull;
+      <a href="/community/" title="Community"><span class="links">Community</span></a>
+      &bull;
+      <a href="/contact/" title="Contact"><span class="links">Contact</span></a>
+    </p>
+    <p>
+      Find us: &nbsp;
+      <a href="https://github.com/hyperledger/sawtooth-core/" target="_blank" title="GitHub"><span  class="links">GitHub</span></a>
+      &bull;
       <a href="https://chat.hyperledger.org/channel/sawtooth" target="_blank" title="#sawtooth chat channel"">Rocket.Chat</a>
+      &bull;
+      <a href="https://twitter.com/search?q=%23HyperledgerSawtooth" target="_blank" title="#sawtooth chat channel"">Twitter</a>
     </p>
     <p>
-      <a href="/docs/" target="_blank" title="Documentation">Documentation</a>
+      Examples: &nbsp;
+      <a href="/examples/seafood.html" target="_blank" title="Seafood Supply Chain Traceability">Seafood Supply Chain Traceability</a>
       &bull;
-      <a href="https://github.com/hyperledger/sawtooth-core/" target="_blank" title="Github">Github</a>
+      <a href="/examples/bond.html" target="_blank" title="Bond Asset Settlement">Bond Asset Settlement</a>
       &bull;
-      <a href="/examples/seafood.html" title="Seafood Supply Chain Traceability">Seafood Supply Chain Traceability</a>
-      &bull;
-      <a href="/examples/bond.html" title="Bond Asset Settlement">Bond Asset Settlement</a>
-      &bull;
-      <a href="/examples/marketplace.html" title="Marketplace Digital Asset Exchange">Marketplace Digital Asset Exchange</a>
+      <a href="/examples/marketplace.html" target="_blank" title="Marketplace Digital Asset Exchange">Marketplace Digital Asset Exchange</a>
     </p>
     <p>
+      Linux Foundation: &nbsp;
       <a href="http://www.linuxfoundation.org/privacy" target="_blank" title="Privacy Policy">Privacy Policy</a>
       &bull;
       <a href="http://www.linuxfoundation.org/terms" target="_blank" title="Terms of Service">Terms of Service</a>

--- a/generator/_config.yml
+++ b/generator/_config.yml
@@ -39,7 +39,7 @@ theme_settings:
       <a href="http://www.linuxfoundation.org/terms" target="_blank" title="Terms of Service">Terms of Service</a>
     </p>
     <p>
-      <small class="copyright">Copyright &copy; 2015-2018 contributors to Hyperledger Sawtooth</small>
+      <small class="copyright">Copyright &copy; 2015-2019 contributors to Hyperledger Sawtooth</small>
     </p>
   permalink: /:categories/:year/:month/:day/:release/:title/
   # Icons

--- a/generator/_config.yml
+++ b/generator/_config.yml
@@ -20,7 +20,7 @@ theme_settings:
   footer_text: >
     <h2>Sawtooth</h2>
     <p>
-      <a href="https://chat.hyperledger.org/channel/sawtooth" target="_blank" title="Rocket Chat">RocketChat</a>
+      <a href="https://chat.hyperledger.org/channel/sawtooth" target="_blank" title="#sawtooth chat channel"">Rocket.Chat</a>
     </p>
     <p>
       <a href="/docs/" target="_blank" title="Documentation">Documentation</a>
@@ -60,7 +60,7 @@ theme_settings:
   stack_exchange:  # Full URL
   steam:
   tumblr:
-  twitter: Hyperledger
+  twitter: \%23HyperledgerSawtooth
   wordpress:
   youtube:
 

--- a/generator/_config.yml
+++ b/generator/_config.yml
@@ -11,7 +11,7 @@ theme_settings:
   title: Hyperledger Sawtooth
   avatar: avatar.png
   gravatar: # Email MD5 hash
-  description: "A website with blog posts and pages" # used by search engines
+  description: "An enterprise-grade solution for distributed ledgers." # used by search engines
 
   # Header and footer text
   header_text: >

--- a/generator/source/_includes/header.html
+++ b/generator/source/_includes/header.html
@@ -16,12 +16,12 @@
 	</div>
 	<nav class="site-nav">
 		<ul>
-			<li>
-				<a class="page-link" href="{{ '/examples' | prepend: site.baseurl }}">
-					Examples
-				</a>
-			</li>
-			{% for page in site.pages %}
+                        {% if site.theme_settings.site_navigation_sort %}
+				{% assign site_pages = site.pages | sort: site.theme_settings.site_navigation_sort %}
+			{% else %}
+				{% assign site_pages = site.pages %}
+			{% endif %}
+			{% for page in site_pages %}
 			{% if page.title and page.hide != true %}
 			<li>
 				<a class="page-link" href="{{ page.url | prepend: site.baseurl }}">
@@ -30,6 +30,11 @@
 			</li>
 			{% endif %}
 			{% endfor %}
+			<li>
+				<a class="page-link" href="{{ '/examples' | prepend: site.baseurl }}">
+					Examples
+				</a>
+			</li>
 			<!-- Social icons from Font Awesome, if enabled -->
 			{% include icons.html %}
 		</ul>

--- a/generator/source/_sass/base/_global.scss
+++ b/generator/source/_sass/base/_global.scss
@@ -51,16 +51,16 @@ h1, h2, h3, h4, h5, h6 {
   word-wrap: normal;
 }
 h1 {
-  font-size: 2.5em;
-}
-h2 {
   font-size: 2em;
 }
-h3 {
+h2 {
   font-size: 1.5em;
 }
-h4 {
+h3 {
   font-size: 1.15em;
+}
+h4 {
+  font-size: 1em;
 }
 blockquote {
     border-left: 2px solid;

--- a/generator/source/_sass/base/_utility.scss
+++ b/generator/source/_sass/base/_utility.scss
@@ -58,6 +58,7 @@ a.button:hover {
 .mininav a {
   color: $link-color;
   text-decoration: none;
+  font-size: 75%;
   padding: 0 1em;
   border-radius: 0.3em;
   border: 1px solid $border-color;

--- a/generator/source/_sass/includes/_footer.scss
+++ b/generator/source/_sass/includes/_footer.scss
@@ -6,5 +6,5 @@
   text-align: center;
   width: 100%;
   color: lighten($text-color, 30%);
-  font-size: 0.9em;
+  font-size: 0.7em;
 }

--- a/generator/source/about.md
+++ b/generator/source/about.md
@@ -3,15 +3,12 @@ layout: page
 title: About
 permalink: /about/
 order: 1
-feature-img: "../examples/img/hero-marketplace-bg.jpg"
+feature-img: "examples/img/hero-bg.jpg"
+feat_img_size: small
 # Copyright (c) 2018 Bitwise IO, Inc.
 # Licensed under Creative Commons Attribution 4.0 International License
 # https://creativecommons.org/licenses/by/4.0/
 ---
-
-![Hyperledger Sawtooth](/examples/img/logo-dark@2x.png)
-
-# Hyperledger Sawtooth
 
 Hyperledger Sawtooth is an enterprise solution for building, deploying, and
 running distributed ledgers (also called blockchains). It provides an extremely

--- a/generator/source/about.md
+++ b/generator/source/about.md
@@ -2,6 +2,7 @@
 layout: page
 title: About
 permalink: /about/
+order: 1
 feature-img: "../examples/img/hero-marketplace-bg.jpg"
 # Copyright (c) 2018 Bitwise IO, Inc.
 # Licensed under Creative Commons Attribution 4.0 International License

--- a/generator/source/community/community.rst
+++ b/generator/source/community/community.rst
@@ -2,6 +2,7 @@
 layout: page
 title: Community
 permalink: /community/
+order: 5
 feature-img: "../examples/img/hero-community-bg.jpg"
 # Copyright (c) 2015-2017, Intel Corporation.
 # Licensed under Creative Commons Attribution 4.0 International License

--- a/generator/source/community/community.rst
+++ b/generator/source/community/community.rst
@@ -3,7 +3,8 @@ layout: page
 title: Community
 permalink: /community/
 order: 5
-feature-img: "../examples/img/hero-community-bg.jpg"
+feature-img: "examples/img/hero-bg.jpg"
+feat_img_size: small
 # Copyright (c) 2015-2017, Intel Corporation.
 # Licensed under Creative Commons Attribution 4.0 International License
 # https://creativecommons.org/licenses/by/4.0/

--- a/generator/source/contact.md
+++ b/generator/source/contact.md
@@ -2,6 +2,7 @@
 layout: page
 title: Contact
 permalink: /contact/
+order: 6
 feature-img: "../examples/img/hero-bond-bg.jpg"
 # Copyright (c) 2018 Bitwise IO, Inc.
 # Licensed under Creative Commons Attribution 4.0 International License

--- a/generator/source/contact.md
+++ b/generator/source/contact.md
@@ -3,7 +3,8 @@ layout: page
 title: Contact
 permalink: /contact/
 order: 6
-feature-img: "../examples/img/hero-bond-bg.jpg"
+feature-img: "examples/img/hero-bg.jpg"
+feat_img_size: small
 # Copyright (c) 2018 Bitwise IO, Inc.
 # Licensed under Creative Commons Attribution 4.0 International License
 # https://creativecommons.org/licenses/by/4.0/

--- a/generator/source/docs/docs.rst
+++ b/generator/source/docs/docs.rst
@@ -2,6 +2,7 @@
 layout: page
 title: Docs
 permalink: /docs/
+order: 3
 feature-img: "../docs/imgs/hero-bg.jpg"
 feat_img_size: small
 # Copyright (c) 2015–2017 Intel Corporation.

--- a/generator/source/docs/docs.rst
+++ b/generator/source/docs/docs.rst
@@ -13,6 +13,8 @@ feat_img_size: small
 Hyperledger Sawtooth Documentation
 ==================================
 
+Documentation for Hyperledger Sawtooth:
+
 .. class:: mininav
 
 `Sawtooth Core`_
@@ -20,8 +22,6 @@ Hyperledger Sawtooth Documentation
 `Sawtooth Sabre`_
 `Sawtooth Seth`_
 `Sawtooth Supply Chain`_
-
-Documentation for Hyperledger Sawtooth
 
 Sawtooth Core
 -------------

--- a/generator/source/faq/faq.rst
+++ b/generator/source/faq/faq.rst
@@ -2,6 +2,7 @@
 layout: page
 title: FAQ
 permalink: /faq/
+order: 4
 feature-img: "../examples/img/hero-faq.png"
 feat_img_size: small
 # Copyright (c) 2018, Intel Corporation.

--- a/generator/source/faq/faq.rst
+++ b/generator/source/faq/faq.rst
@@ -3,7 +3,7 @@ layout: page
 title: FAQ
 permalink: /faq/
 order: 4
-feature-img: "../examples/img/hero-faq.png"
+feature-img: "examples/img/hero-bg.jpg"
 feat_img_size: small
 # Copyright (c) 2018, Intel Corporation.
 # Licensed under Creative Commons Attribution 4.0 International License

--- a/generator/source/index.md
+++ b/generator/source/index.md
@@ -1,14 +1,14 @@
 ---
 hide: true
 layout: page
+title: Hyperledger Sawtooth
 permalink: /
 feature-img: "examples/img/hero-bg.jpg"
+feat_img_size: small
 # Copyright (c) 2018 Bitwise IO, Inc.
 # Licensed under Creative Commons Attribution 4.0 International License
 # https://creativecommons.org/licenses/by/4.0/
 ---
-
-# Hyperledger Sawtooth
 
 Hyperledger Sawtooth is an enterprise solution for building, deploying, and
 running distributed ledgers (also called blockchains). It provides an extremely

--- a/generator/source/releases.md
+++ b/generator/source/releases.md
@@ -10,7 +10,7 @@ feat_img_size: small
 # https://creativecommons.org/licenses/by/4.0/
 ---
 
-# Hyperledger Sawtooth
+# Hyperledger Sawtooth releases
 
 [Release 1.1 (Bumper)][bumper-release-notes]
 

--- a/generator/source/releases.md
+++ b/generator/source/releases.md
@@ -2,6 +2,7 @@
 layout: page
 title: Releases
 permalink: /release/
+order: 2
 feature-img: "examples/img/hero-bg.jpg"
 feat_img_size: small
 # Copyright (c) 2018 Bitwise IO, Inc.


### PR DESCRIPTION
Make general improvements to the Sawtooth website: 

- Update copyright end date (from 2018 to 2019)

- Replace boilerplate description in page template with Sawtooth-specific content (was "A website with blog posts and pages")

- Fix Rocket.Chat and Twitter links

- Improve order of header navigation menu per web best practices: About first, Contact last (not counting Examples, which is handled differently so must be last)

- Improve page footer per web best practices: smaller font; complete site links plus labels for other items (now complete); fix targets (link opens in new tab vs same tab)

- Make header images and titles (headers) consistent 
