### PR TITLE
Tidy FAQ pages

### DIFF
--- a/generator/source/faq/client.rst
+++ b/generator/source/faq/client.rst
@@ -13,7 +13,7 @@ Sawtooth FAQ: Client
 
 .. class:: mininav
 
-PREVIOUS_ FAQ_ NEXT_
+PREVIOUS_ TOP_ NEXT_
 
 .. contents::
 
@@ -120,10 +120,10 @@ Until Rust and the RustSDK are a bit more mature, I still recommend using a Dock
 
 .. class:: mininav
 
-PREVIOUS_ FAQ_ NEXT_
+PREVIOUS_ TOP_ NEXT_
 
 .. _PREVIOUS: /faq/consensus/
-.. _FAQ: /faq/
+.. _TOP: /faq/
 .. _NEXT: /faq/rest/
 .. _Colin McCullough: https://github.com/colincmcc
 

--- a/generator/source/faq/consensus.rst
+++ b/generator/source/faq/consensus.rst
@@ -13,7 +13,7 @@ Sawtooth FAQ: Consensus Algorithms (including PoET)
 
 .. class:: mininav
 
-PREVIOUS_ FAQ_ NEXT_
+PREVIOUS_ TOP_ NEXT_
 
 .. contents::
 
@@ -277,10 +277,10 @@ https://software.intel.com/sites/default/files/managed/7e/3b/ias-api-spec.pdf
 
 .. class:: mininav
 
-PREVIOUS_ FAQ_ NEXT_
+PREVIOUS_ TOP_ NEXT_
 
 .. _PREVIOUS: /faq/validator/
-.. _FAQ: /faq/
+.. _TOP: /faq/
 .. _NEXT: /faq/client/
 .. _Settings: /faq/settings/
 

--- a/generator/source/faq/docker.rst
+++ b/generator/source/faq/docker.rst
@@ -13,7 +13,7 @@ Sawtooth FAQ: Using Docker
 
 .. class:: mininav
 
-PREVIOUS_ FAQ_ NEXT_
+PREVIOUS_ TOP_ NEXT_
 
 .. contents::
 
@@ -237,10 +237,10 @@ For example the following removes containers and volumes
 
 .. class:: mininav
 
-PREVIOUS_ FAQ_ NEXT_
+PREVIOUS_ TOP_ NEXT_
 
 .. _PREVIOUS: /faq/rest/
-.. _FAQ: /faq/
+.. _TOP: /faq/
 .. _NEXT: /faq/upgrade/
 
 © Copyright 2018, Intel Corporation.

--- a/generator/source/faq/docker.rst
+++ b/generator/source/faq/docker.rst
@@ -239,7 +239,7 @@ For example the following removes containers and volumes
 
 PREVIOUS_ TOP_ NEXT_
 
-.. _PREVIOUS: /faq/rest/
+.. _PREVIOUS: /faq/permissioning/
 .. _TOP: /faq/
 .. _NEXT: /faq/upgrade/
 

--- a/generator/source/faq/faq.rst
+++ b/generator/source/faq/faq.rst
@@ -26,7 +26,9 @@ Frequently-asked Questions
 - `Sawtooth Consensus Algorithms (including PoET)`_
 - `Sawtooth Client`_
 - `Sawtooth REST API`_
+- `Sawtooth Permissioning`_
 - `Using Docker with Sawtooth`_
+- `Upgrading Sawtooth`_
 
 Appendix
 --------
@@ -59,11 +61,12 @@ NEXT_
 .. _Sawtooth Consensus Algorithms (including PoET): consensus
 .. _Sawtooth Client: client
 .. _Sawtooth REST API: rest
+.. _Sawtooth Permissioning: permissioning
 .. _Using Docker with Sawtooth: docker
+.. _Upgrading Sawtooth: upgrade
 .. _Sawtooth FAQ Glossary: glossary
 .. _Sawtooth Transaction Family Prefixes: prefixes
 .. _Sawtooth Settings: settings
-.. _Sawooth Permissioning: permissioning
 .. _Sawtooth Videos: videos
 .. _GitHub: https://github.com/hyperledger/sawtooth-website
 .. _Developer Certificate of Origin (DCO): https://developercertificate.org/

--- a/generator/source/faq/faq.rst
+++ b/generator/source/faq/faq.rst
@@ -19,23 +19,23 @@ https://chat.hyperledger.org/channel/sawtooth
 Sawtooth FAQ Sections
 ---------------------
 
-- `Sawtooth in General`_
-- `Sawtooth Installation and Configuration`_
-- `Sawtooth Transaction Processing`_
-- `Sawtooth Validator`_
-- `Sawtooth Consensus Algorithms (including PoET)`_
-- `Sawtooth Client`_
-- `Sawtooth REST API`_
-- `Sawtooth Permissioning`_
-- `Using Docker with Sawtooth`_
-- `Upgrading Sawtooth`_
+- `Hyperledger Sawtooth in General`_
+- `Installation and Configuration`_
+- `Transaction Processing`_
+- `Validator`_
+- `Consensus Algorithms (including PoET)`_
+- `Client`_
+- `REST API`_
+- `Permissioning`_
+- `Using Docker`_
+- `Upgrading Hyperledger Sawtooth`_
 
 FAQ Appendixes
 --------------
 
-- `Sawtooth FAQ Glossary`_
-- `Sawtooth Transaction Family Prefixes`_
-- `Sawtooth Settings`_
+- `Sawtooth Glossary`_
+- `Transaction Family Prefixes`_
+- `Configuration Settings`_
 - `Sawtooth Videos`_
 
 Contributing to This FAQ
@@ -54,19 +54,19 @@ This sign-off means you agree the commit satisfies the
 
 NEXT_
 
-.. _Sawtooth in General: sawtooth
-.. _Sawtooth Installation and Configuration: installation
-.. _Sawtooth Transaction Processing: transaction-processing
-.. _Sawtooth Validator: validator
-.. _Sawtooth Consensus Algorithms (including PoET): consensus
-.. _Sawtooth Client: client
-.. _Sawtooth REST API: rest
-.. _Sawtooth Permissioning: permissioning
-.. _Using Docker with Sawtooth: docker
-.. _Upgrading Sawtooth: upgrade
-.. _Sawtooth FAQ Glossary: glossary
-.. _Sawtooth Transaction Family Prefixes: prefixes
-.. _Sawtooth Settings: settings
+.. _Hyperledger Sawtooth in General: sawtooth
+.. _Installation and Configuration: installation
+.. _Transaction Processing: transaction-processing
+.. _Validator: validator
+.. _Consensus Algorithms (including PoET): consensus
+.. _Client: client
+.. _REST API: rest
+.. _Permissioning: permissioning
+.. _Using Docker: docker
+.. _Upgrading Hyperledger Sawtooth: upgrade
+.. _Sawtooth Glossary: glossary
+.. _Transaction Family Prefixes: prefixes
+.. _Configuration Settings: settings
 .. _Sawtooth Videos: videos
 .. _GitHub: https://github.com/hyperledger/sawtooth-website
 .. _Developer Certificate of Origin (DCO): https://developercertificate.org/

--- a/generator/source/faq/faq.rst
+++ b/generator/source/faq/faq.rst
@@ -11,13 +11,13 @@ feat_img_size: small
 Hyperledger Sawtooth FAQ
 ========================
 
-Frequently-asked Questions (FAQ) for Hyperledger Sawtooth.
-Many questions and answers originated from the Sawtooth chat channel at
+Answers to frequently asked questions for Hyperledger Sawtooth.
+Many questions and answers originated from the #sawtooth Rocket.Chat channel at
 https://chat.hyperledger.org/channel/sawtooth
 
 
-Frequently-asked Questions
---------------------------
+Sawtooth FAQ Sections
+---------------------
 
 - `Sawtooth in General`_
 - `Sawtooth Installation and Configuration`_
@@ -30,16 +30,16 @@ Frequently-asked Questions
 - `Using Docker with Sawtooth`_
 - `Upgrading Sawtooth`_
 
-Appendix
---------
+FAQ Appendixes
+--------------
 
 - `Sawtooth FAQ Glossary`_
 - `Sawtooth Transaction Family Prefixes`_
 - `Sawtooth Settings`_
 - `Sawtooth Videos`_
 
-Contributing
-------------
+Contributing to This FAQ
+------------------------
 
 This FAQ is licensed under Creative Commons Attribution 4.0 International
 License. You may obtain a copy of the license at:

--- a/generator/source/faq/glossary.rst
+++ b/generator/source/faq/glossary.rst
@@ -8,8 +8,8 @@ permalink: /faq/glossary/
 # Licensed under Creative Commons Attribution 4.0 International License
 # https://creativecommons.org/licenses/by/4.0/
 ---
-Sawtooth: Glossary
-==================
+FAQ Appendix: Sawtooth Glossary
+===============================
 
 .. class:: mininav
 

--- a/generator/source/faq/installation.rst
+++ b/generator/source/faq/installation.rst
@@ -12,7 +12,7 @@ Sawtooth FAQ: Installation and Configuration
 ============================================
 .. class:: mininav
 
-PREVIOUS_ FAQ_ NEXT_
+PREVIOUS_ TOP_ NEXT_
 
 .. contents::
 
@@ -325,10 +325,10 @@ They work for Sawtooth 1.1, but for nightly builds the consensus engine setting 
 
 .. class:: mininav
 
-PREVIOUS_ FAQ_ NEXT_
+PREVIOUS_ TOP_ NEXT_
 
 .. _PREVIOUS: /faq/sawtooth/
-.. _FAQ: /faq/
+.. _TOP: /faq/
 .. _NEXT: /faq/transaction-processing/
 
 © Copyright 2018, Intel Corporation.

--- a/generator/source/faq/permissioning.rst
+++ b/generator/source/faq/permissioning.rst
@@ -32,9 +32,9 @@ Refer https://sawtooth.hyperledger.org/docs/core/nightly/master/sysadmin_guide/c
 
 PREVIOUS_ TOP_ NEXT_
 
-.. _PREVIOUS: /faq/settings/
+.. _PREVIOUS: /faq/rest/
 .. _TOP: /faq/
-.. _NEXT: /faq/videos/
+.. _NEXT: /faq/docker/
 
 © Copyright 2018, Intel Corporation.
 

--- a/generator/source/faq/permissioning.rst
+++ b/generator/source/faq/permissioning.rst
@@ -13,7 +13,7 @@ Sawtooth FAQ: Permissioning
 
 .. class:: mininav
 
-PREVIOUS_ FAQ_ NEXT_
+PREVIOUS_ TOP_ NEXT_
 
 .. contents::
 
@@ -30,10 +30,10 @@ Refer https://sawtooth.hyperledger.org/docs/core/nightly/master/sysadmin_guide/c
 
 .. class:: mininav
 
-PREVIOUS_ FAQ_ NEXT_
+PREVIOUS_ TOP_ NEXT_
 
 .. _PREVIOUS: /faq/settings/
-.. _FAQ: /faq/
+.. _TOP: /faq/
 .. _NEXT: /faq/videos/
 
 © Copyright 2018, Intel Corporation.

--- a/generator/source/faq/prefixes.rst
+++ b/generator/source/faq/prefixes.rst
@@ -8,8 +8,8 @@ permalink: /faq/prefixes/
 # Licensed under Creative Commons Attribution 4.0 International License
 # https://creativecommons.org/licenses/by/4.0/
 ---
-Appendix: Sawtooth Transaction Family Prefixes
-==============================================
+FAQ Appendix: Transaction Family Prefixes
+=========================================
 .. class:: mininav
 
 PREVIOUS_ FAQ_ NEXT_

--- a/generator/source/faq/rest.rst
+++ b/generator/source/faq/rest.rst
@@ -12,7 +12,7 @@ Sawtooth FAQ: REST API
 ======================
 .. class:: mininav
 
-PREVIOUS_ FAQ_ NEXT_
+PREVIOUS_ TOP_ NEXT_
 
 .. contents::
 
@@ -130,10 +130,10 @@ It means the command format is correct, but the identifier does not exist.
 
 .. class:: mininav
 
-PREVIOUS_ FAQ_ NEXT_
+PREVIOUS_ TOP_ NEXT_
 
 .. _PREVIOUS: /faq/client/
-.. _FAQ: /faq/
+.. _TOP: /faq/
 .. _NEXT: /faq/docker/
 
 © Copyright 2018, Intel Corporation.

--- a/generator/source/faq/rest.rst
+++ b/generator/source/faq/rest.rst
@@ -134,6 +134,6 @@ PREVIOUS_ TOP_ NEXT_
 
 .. _PREVIOUS: /faq/client/
 .. _TOP: /faq/
-.. _NEXT: /faq/docker/
+.. _NEXT: /faq/permissioning/
 
 © Copyright 2018, Intel Corporation.

--- a/generator/source/faq/sawtooth.rst
+++ b/generator/source/faq/sawtooth.rst
@@ -12,7 +12,7 @@ Sawtooth FAQ: Hyperledger Sawtooth in General
 =============================================
 .. class:: mininav
 
-PREVIOUS_ FAQ_ NEXT_
+TOP_ NEXT_
 
 .. contents::
 
@@ -385,10 +385,9 @@ network.consensus
 
 .. class:: mininav
 
-PREVIOUS_ FAQ_ NEXT_
+TOP_ NEXT_
 
-.. _PREVIOUS: /faq/
-.. _FAQ: /faq/
+.. _TOP: /faq/
 .. _NEXT: /faq/installation/
 .. _videos: /faq/videos/
 

--- a/generator/source/faq/settings.rst
+++ b/generator/source/faq/settings.rst
@@ -190,6 +190,6 @@ PREVIOUS_ FAQ_ NEXT_
 
 .. _PREVIOUS: /faq/prefixes/
 .. _FAQ: /faq/
-.. _NEXT: /faq/permissioning/
+.. _NEXT: /faq/videos/
 
 © Copyright 2018, Intel Corporation.

--- a/generator/source/faq/settings.rst
+++ b/generator/source/faq/settings.rst
@@ -8,8 +8,8 @@ permalink: /faq/settings/
 # Licensed under Creative Commons Attribution 4.0 International License
 # https://creativecommons.org/licenses/by/4.0/
 ---
-Appendix: Sawtooth Settings
-===========================
+FAQ Appendix: Configuration Settings
+====================================
 .. class:: mininav
 
 PREVIOUS_ FAQ_ NEXT_

--- a/generator/source/faq/transaction-processing.rst
+++ b/generator/source/faq/transaction-processing.rst
@@ -12,7 +12,7 @@ Sawtooth FAQ: Transaction Processing
 ====================================
 .. class:: mininav
 
-PREVIOUS_ FAQ_ NEXT_
+PREVIOUS_ TOP_ NEXT_
 
 .. contents::
 
@@ -283,10 +283,10 @@ There will likely be a difference between the publishing and validation executio
 
 .. class:: mininav
 
-PREVIOUS_ FAQ_ NEXT_
+PREVIOUS_ TOP_ NEXT_
 
 .. _PREVIOUS: /faq/installation/
-.. _FAQ: /faq/
+.. _TOP: /faq/
 .. _NEXT: /faq/validator/
 
 © Copyright 2018, Intel Corporation.

--- a/generator/source/faq/upgrade.rst
+++ b/generator/source/faq/upgrade.rst
@@ -13,7 +13,7 @@ Sawtooth FAQ: Upgrading Hyperledger Sawtooth
 
 .. class:: mininav
 
-PREVIOUS_ FAQ_ NEXT_
+PREVIOUS_ TOP_ NEXT_
 
 .. contents::
 
@@ -75,10 +75,10 @@ General practice for deploying a Hyperledger Sawtooth application
 
 .. class:: mininav
 
-PREVIOUS_ FAQ_ NEXT_
+PREVIOUS_ TOP_ NEXT_
 
 .. _PREVIOUS: /faq/docker/
-.. _FAQ: /faq/
+.. _TOP: /faq/
 .. _NEXT: /faq/glossary/
 
 © Copyright 2018, Intel Corporation.

--- a/generator/source/faq/validator.rst
+++ b/generator/source/faq/validator.rst
@@ -12,7 +12,7 @@ Sawtooth FAQ: Validator
 =======================
 .. class:: mininav
 
-PREVIOUS_ FAQ_ NEXT_
+PREVIOUS_ TOP_ NEXT_
 
 .. contents::
 
@@ -329,10 +329,10 @@ There is no limit, other than the available storage for a node.
 
 .. class:: mininav
 
-PREVIOUS_ FAQ_ NEXT_
+PREVIOUS_ TOP_ NEXT_
 
 .. _PREVIOUS: /faq/transaction-processing/
-.. _FAQ: /faq/
+.. _TOP: /faq/
 .. _NEXT: /faq/consensus/
 
 © Copyright 2018, Intel Corporation.

--- a/generator/source/faq/videos.rst
+++ b/generator/source/faq/videos.rst
@@ -164,7 +164,7 @@ PoET Consensus on Sawtooth Lake (Jamie Jason, Intel)
 
 PREVIOUS_ TOP_
 
-.. _PREVIOUS: /faq/permissioning/
+.. _PREVIOUS: /faq/settings/
 .. _TOP: /faq/
 .. _20180927-sawtooth-forum.mp4: https://drive.google.com/file/d/1-XP-DflRJvAekACYv0tAQsbyl2VnN80o/view
 .. _20180927-sawtooth-forum.mp4: https://drive.google.com/file/d/1-XP-DflRJvAekACYv0tAQsbyl2VnN80o/view

--- a/generator/source/faq/videos.rst
+++ b/generator/source/faq/videos.rst
@@ -12,7 +12,7 @@ Appendix: Sawtooth Videos
 =========================
 .. class:: mininav
 
-PREVIOUS_ FAQ_
+PREVIOUS_ TOP_
 
 .. contents::
 
@@ -162,10 +162,10 @@ PoET Consensus on Sawtooth Lake (Jamie Jason, Intel)
 
 .. class:: mininav
 
-PREVIOUS_ FAQ_
+PREVIOUS_ TOP_
 
 .. _PREVIOUS: /faq/permissioning/
-.. _FAQ: /faq/
+.. _TOP: /faq/
 .. _20180927-sawtooth-forum.mp4: https://drive.google.com/file/d/1-XP-DflRJvAekACYv0tAQsbyl2VnN80o/view
 .. _20180927-sawtooth-forum.mp4: https://drive.google.com/file/d/1-XP-DflRJvAekACYv0tAQsbyl2VnN80o/view
 .. _20180913-sawtooth-tech-forum.mp4: https://drive.google.com/file/d/1jnL4nhYgY7zSqKF-WolNdYQJQa68m0al/view

--- a/generator/source/faq/videos.rst
+++ b/generator/source/faq/videos.rst
@@ -8,8 +8,8 @@ permalink: /faq/videos/
 # Licensed under Creative Commons Attribution 4.0 International License
 # https://creativecommons.org/licenses/by/4.0/
 ---
-Appendix: Sawtooth Videos
-=========================
+FAQ Appendix: Sawtooth Videos
+=============================
 .. class:: mininav
 
 PREVIOUS_ TOP_


### PR DESCRIPTION
- Fix FAQ nav buttons: Change FAQ to TOP per webnav standards; remove unnecessary PREVIOUS buttons

- Fix FAQ section order and NEXT/PREVIOUS buttons: Put Permissioning and Update in the FAQ section list; adjusted the NEXT/PREVIOUS buttons

- Fix FAQ wording, punctuation, and headings: Remove hyphen from "frequently asked questions"; clarify headings in top FAQ page

- Make FAQ section titles and link text consistent
