### PR TITLE
Add css for blockquotes

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -50,6 +50,12 @@ img {
     border-color: var(--sawtooth-blue);
 }
 
+blockquote {
+    background-color: var(--light-gray);
+    border-radius: 5px;
+    padding: 10px;
+}
+
 /* Header */
 
 #header {


### PR DESCRIPTION
Blockquotes are used through the docs for Notes and
simular items but without any css the blocks look like
regular markdown. This commit wraps the block quotes
into a light grey box.Add css for blockquotes

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>