### PR TITLE
Add a first cut at a portion of the 1.2 docs sidebar

### DIFF
--- a/_includes/1.2/left_sidebar.html
+++ b/_includes/1.2/left_sidebar.html
@@ -21,6 +21,7 @@
     <div class="left-sidebar-group">
         <div class="left-sidebar-header">Getting Started</div>
         <a href="{% link docs/1.2/index.md %}">Introduction</a>
+        <a href="{% link docs/1.2/index.md %}">Glossary</a>
     </div>
     <div class="left-sidebar-group">
         <div class="left-sidebar-header">Application Developer's Guide</div>
@@ -40,5 +41,92 @@
         <a href="{% link docs/1.2/index.md %}">Address and Namespace Design</a>
         <a href="{% link docs/1.2/index.md %}">Namespace Restriction</a>
         <a href="{% link docs/1.2/index.md %}">Subscribing to Events</a>
+    </div>
+    <div class="left-sidebar-group">
+        <div class="left-sidebar-header">Architecture Guide</div>
+        <a href="{% link docs/1.2/index.md %}">Overview</a>
+        <a href="{% link docs/1.2/index.md %}">Global State</a>
+        <a href="{% link docs/1.2/index.md %}">Transactions and Batches</a>
+        <a href="{% link docs/1.2/index.md %}">Journal</a>
+        <a href="{% link docs/1.2/index.md %}">Transaction Scheduling</a>
+        <a href="{% link docs/1.2/index.md %}">REST API</a>
+        <a href="{% link docs/1.2/index.md %}">Sawtooth Network</a>
+        <a href="{% link docs/1.2/index.md %}">Permissioning Design</a>
+        <a href="{% link docs/1.2/index.md %}">Injecting Batches and On-Chain Blcok Validation Rules</a>
+        <a href="{% link docs/1.2/index.md %}">Events and Transaction Receipts</a>
+        <a href="{% link docs/1.2/index.md %}">PoET 1.0 Consensus</a>
+    </div>
+    <div class="left-sidebar-group">
+        <div class="left-sidebar-header">Transaction Family Specifciations</div>
+        <a href="{% link docs/1.2/index.md %}">Settings</a>
+        <a href="{% link docs/1.2/index.md %}">Identity</a>
+        <a href="{% link docs/1.2/index.md %}">BlockInfo</a>
+        <a href="{% link docs/1.2/index.md %}">IntegerKey</a>
+        <a href="{% link docs/1.2/index.md %}">XO</a>
+        <a href="{% link docs/1.2/index.md %}">PoET Validator Registry</a>
+        <a href="{% link docs/1.2/index.md %}">Smallbank</a>
+    </div>
+    <div class="left-sidebar-group">
+        <div class="left-sidebar-header">System Administrator's Guide</div>
+        <a href="{% link docs/1.2/index.md %}">Setting Up a Sawtooth Network</a>
+        <a href="{% link docs/1.2/index.md %}">Using Sawtooth with PoET-SGX</a>
+        <a href="{% link docs/1.2/index.md %}">Setting the Allowed Transaction Types (Optional)</a>
+        <a href="{% link docs/1.2/index.md %}">Adding Authorized Users for Settings Proposals</a>
+        <a href="{% link docs/1.2/index.md %}">Using Proxy Server to Authorize the REST API</a>
+        <a href="{% link docs/1.2/index.md %}">Configuring Validator and Transactor Permissions</a>
+        <a href="{% link docs/1.2/index.md %}">Using Grafana to Display Sawtooth Metrics</a>
+        <a href="{% link docs/1.2/index.md %}">About Dynamic Consensus</a>
+        <a href="{% link docs/1.2/index.md %}">Adding or Removing a PBFT Node</a>
+        <a href="{% link docs/1.2/index.md %}">About Sawtooth Configuration Files</a>
+    </div>
+    <div class="left-sidebar-group">
+        <div class="left-sidebar-header">SDK and API References</div>
+        <a href="{% link docs/1.2/index.md %}">Go</a>
+        <a href="{% link docs/1.2/index.md %}">Java</a>
+        <a href="{% link docs/1.2/index.md %}">JavaScript</a>
+        <a href="{% link docs/1.2/index.md %}">Python</a>
+        <a href="{% link docs/1.2/index.md %}">Rust</a>
+        <a href="{% link docs/1.2/index.md %}">Swift</a>
+        <a href="{% link docs/1.2/index.md %}">REST API Reference</a>
+    </div>
+    <div class="left-sidebar-group">
+        <div class="left-sidebar-header">CLI Command Reference</div>
+        <a href="{% link docs/1.2/index.md %}">sawtooth</a>
+        <a href="{% link docs/1.2/index.md %}">sawtooth-vaidator</a>
+        <a href="{% link docs/1.2/index.md %}">sawtooth-rest-api</a>
+        <a href="{% link docs/1.2/index.md %}">sawadm</a>
+        <a href="{% link docs/1.2/index.md %}">sawnet</a>
+        <a href="{% link docs/1.2/index.md %}">sawset</a>
+        <a href="{% link docs/1.2/index.md %}">identity-tp</a>
+        <a href="{% link docs/1.2/index.md %}">intkey</a>
+        <a href="{% link docs/1.2/index.md %}">settings-tp</a>
+        <a href="{% link docs/1.2/index.md %}">xo</a>
+    </div>
+    <div class="left-sidebar-group">
+        <div class="left-sidebar-header">PBFT</div>
+        <a href="{% link docs/1.2/index.md %}">Introduction</a>
+        <a href="{% link docs/1.2/index.md %}">Using PBFT Consensus</a>
+        <a href="{% link docs/1.2/index.md %}">PBFT Architecture</a>
+        <a href="{% link docs/1.2/index.md %}">Configuring PBFT</a>
+        <a href="{% link docs/1.2/index.md %}">Installing and Testing PBFT</a>
+        <a href="{% link docs/1.2/index.md %}">Glossary</a>
+    </div>
+    <div class="left-sidebar-group">
+        <div class="left-sidebar-header">Sabre</div>
+        <a href="{% link docs/1.2/index.md %}">Sabre Transaction Family</a>
+        <a href="{% link docs/1.2/index.md %}">Sabre Application Developer's Guide</a>
+        <a href="{% link docs/1.2/index.md %}">Sabre CLI Reference</a>
+        <a href="{% link docs/1.2/index.md %}">Smart Permissions</a>
+        <a href="{% link docs/1.2/index.md %}">Sabre and Sawtooth Version Compatibility</a>
+    </div>
+    <div class="left-sidebar-group">
+        <div class="left-sidebar-header">Seth</div>
+        <a href="{% link docs/1.2/index.md %}">Introduction</a>
+        <a href="{% link docs/1.2/index.md %}">Getting Started</a>
+        <a href="{% link docs/1.2/index.md %}">Contracts</a>
+        <a href="{% link docs/1.2/index.md %}">Permissions</a>
+        <a href="{% link docs/1.2/index.md %}">Developing DApps</a>
+        <a href="{% link docs/1.2/index.md %}">Seth Transaction Family Specification</a>
+        <a href="{% link docs/1.2/index.md %}">CLI Reference</a>
     </div>
 </div>

--- a/_includes/1.2/left_sidebar.html
+++ b/_includes/1.2/left_sidebar.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2018-2020 Cargill Incorporated
+  Copyright 2018-2022 Cargill Incorporated
   Licensed under Creative Commons Attribution 4.0 International License
   https://creativecommons.org/licenses/by/4.0/
 -->
@@ -11,9 +11,34 @@
     <div class="dropdown-menu">
         <div class="dropdown-header">Stable</div>
         <a class="dropdown-item" href="/docs/{{ site.data.general.latest_version }}/">
-            Latest ({{ site.data.general.latest_version }})
+            Latest (v{{ site.data.general.latest_version }})
         </a>
         <a class="dropdown-item" href="{% link docs/1.1/index.md %}">v1.1</a>
         <a class="dropdown-item" href="{% link docs/1.0/index.md %}">v1.0</a>
+    </div>
+</div>
+<div id="left-sidebar-links" class="collapse">
+    <div class="left-sidebar-group">
+        <div class="left-sidebar-header">Getting Started</div>
+        <a href="{% link docs/1.2/index.md %}">Introduction</a>
+    </div>
+    <div class="left-sidebar-group">
+        <div class="left-sidebar-header">Application Developer's Guide</div>
+        <a href="{% link docs/1.2/index.md %}">Overview</a>
+        <a href="{% link docs/1.2/index.md %}">Transaction Family Overview</a>
+        <a href="{% link docs/1.2/index.md %}">Setting Up a Sawtooth Node for Testing</a>
+        <a href="{% link docs/1.2/index.md %}">Creating a Sawtooth Test Network</a>
+        <a href="{% link docs/1.2/index.md %}">Playing with the XO Transaction Family</a>
+        <a href="{% link docs/1.2/index.md %}">Summary of Available SDKs</a>
+        <a href="{% link docs/1.2/index.md %}">Using the Go SDK</a>
+        <a href="{% link docs/1.2/index.md %}">Using the Java SDK</a>
+        <a href="{% link docs/1.2/index.md %}">Using the JavasScript SDK</a>
+        <a href="{% link docs/1.2/index.md %}">Using the Python SDK</a>
+        <a href="{% link docs/1.2/index.md %}">Using the Rust SDK</a>
+        <a href="{% link docs/1.2/index.md %}">Using the Swift SDK</a>
+        <a href="{% link docs/1.2/index.md %}">Development Without an SDK</a>
+        <a href="{% link docs/1.2/index.md %}">Address and Namespace Design</a>
+        <a href="{% link docs/1.2/index.md %}">Namespace Restriction</a>
+        <a href="{% link docs/1.2/index.md %}">Subscribing to Events</a>
     </div>
 </div>


### PR DESCRIPTION
This adds Getting Started and Application Developer's Guide sections,
with all links pointing to the index currently (to be changed as the
pages become available).
