### PR TITLE
Add development config file

### DIFF
--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -1,0 +1,15 @@
+# Copyright 2022 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+url: http://localhost:8080

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
     entrypoint:  |
       bash -c "
         rm -rf  _site
-        jekyll serve --config ./_config.yml
+        jekyll serve --config ./_config.yml,./_config_dev.yml
       "
 
   sawtooth-docs-apache:


### PR DESCRIPTION
This allows for overriding values for development because settings in
later file override settings in earlier files with the `--config` option.

Overrding `url:` for development is desirable for testing redirects locally.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>