### PR TITLE
Fix markdown for PBFT documents

### DIFF
--- a/docs/1.2/pbft/architecture.md
+++ b/docs/1.2/pbft/architecture.md
@@ -1,170 +1,153 @@
----
-title: PBFT Architecture
----
+# PBFT Architecture
 
-The Sawtooth PBFT algorithm is a voting-based consensus algorithm with
-Byzantine fault tolerance, which ensures [safety and
-liveness](https://en.wikipedia.org/wiki/Liveness#Liveness_and_safety).
-The network can tolerate a certain number of \"bad\" nodes. As long as
-this number is not exceeded, the network will work properly. In
-addition, blocks committed by nodes are final, so there are no forks in
-the network.
+The Sawtooth PBFT algorithm is a voting-based consensus algorithm with Byzantine
+fault tolerance, which ensures [safety and
+liveness](https://en.wikipedia.org/wiki/Liveness#Liveness_and_safety).  The
+network can tolerate a certain number of "bad" nodes. As long as this number
+is not exceeded, the network will work properly. In addition, blocks committed
+by nodes are final, so there are no forks in the network.
 
 The nodes on the network send many messages to reach consensus, commit
-blocks, and maintain a healthy leader node, called a [primary
-node]{.title-ref}. The network switches to a new primary (called a [view
-change]{.title-ref}) at regular intervals, as well as when the current
+blocks, and maintain a healthy leader node, called a *primary
+node*. The network switches to a new primary (called a *view
+change*) at regular intervals, as well as when the current
 primary is faulty.
 
--   The primary node builds and publishes blocks.
--   The other nodes (called [secondary nodes]{.title-ref}) vote on
-    blocks and the health of the leader.
+- The primary node builds and publishes blocks.
+- The other nodes (called *secondary nodes*) vote on
+  blocks and the health of the leader.
 
-Sawtooth PBFT runs on each node in the network as a [consensus
-engine]{.title-ref}, a separate process that handles consensus-related
-functionality and communicates with the validator through the consensus
-API.
+Sawtooth PBFT runs on each node in the network as a *consensus engine*, a
+separate process that handles consensus-related functionality and communicates
+with the validator through the consensus API.
 
 The following sections describe Sawtooth PBFT architecture:
 
--   `Network overview <network-overview-label>`{.interpreted-text
-    role="ref"}: Describes PBFT fault tolerance, view changes, sequence
-    numbers, and the information stored by each node
--   `Consensus messages <consensus-messages-label>`{.interpreted-text
-    role="ref"}: Explains consensus message structures and message types
--   `Sawtooth PBFT operation <pbft-operation-label>`{.interpreted-text
-    role="ref"}: Shows how the algorithm handles initialization, normal
-    mode (block processing), and view changes
+- [Network overview](#network-overview-label): Describes PBFT fault tolerance,
+  view changes, sequence numbers, and the information stored by each node
+- [Consensus messages](#consensus-messages-label): Explains consensus message
+  structures and message types
+- [Sawtooth PBFT operation](#pbft-operation-label): Shows how the algorithm
+  handles initialization, normal mode (block processing), and view changes
 
-# Network Overview {#network-overview-label}
+## Network Overview {#network-overview-label}
 
 <!--
   Licensed under Creative Commons Attribution 4.0 International License
   https://creativecommons.org/licenses/by/4.0/
 -->
 
-## Fault Tolerance
+### Fault Tolerance
 
-A PBFT network consists of nodes that are ordered from 0 to
-[n-1]{.title-ref}, where [n]{.title-ref} is the total number of nodes in
-the network. The
-`on-chain setting <on-chain-settings-label>`{.interpreted-text
-role="ref"} `sawtooth.consensus.pbft.members` lists all PBFT member
-nodes and determines the node order.
+A PBFT network consists of nodes that are ordered from 0 to *n-1*, where *n* is
+the total number of nodes in the network. The [on chain settings]({% link
+docs/1.2/pbft/configuring-pbft.md %}#on-chain-settings-label)
+`sawtooth.consensus.pbft.members` lists all PBFT member nodes and determines the
+node order.
 
 The PBFT algorithm guarantees network
 [safety](https://en.wikipedia.org/wiki/Liveness#Liveness_and_safety) as
-long as the number of faulty nodes remains below the required
-percentage. The maximum number of faulty nodes that the network can
-tolerate is determined by the formula $f = \frac{n - 1}{3}$. In other
-words, no more than one third of the nodes (rounded down) can be
-unreachable or dishonest at any given time.
+long as the number of faulty nodes remains below the required percentage. The
+maximum number of faulty nodes that the network can tolerate is determined by
+the formula `f = (n - 1) / 3`. In other words, no more than one third of the
+nodes (rounded down) can be unreachable or dishonest at any given time.
 
 For example, a four-node network can tolerate one faulty node. (PBFT
 requires a minimum of four nodes in order to maintain Byzantine fault
 tolerance.) Increasing the size of the network reduces the likelihood
-that all $\frac{n - 1}{3}$ nodes would be faulty at the same time.
+that all `f = (n - 1) / 3` nodes would be faulty at the same time.
 
-## View Changes: Choosing a New Primary {#view-changes-choosing-primary-label}
+### View Changes: Choosing a New Primary {#view-changes-choosing-primary-label}
 
-A [view]{.title-ref} is the period of time that a given node is the
-primary, so a [view change]{.title-ref} means switching to a different
-primary node. The next primary is selected in a round-robin (circular)
-fashion, according to the order of nodes listed in the
-`on-chain setting <on-chain-settings-label>`{.interpreted-text
-role="ref"} `sawtooth.consensus.pbft.members`.
+A *view* is the period of time that a given node is the primary, so a *view
+change* means switching to a different primary node. The next primary is
+selected in a round-robin (circular) fashion, according to the order of nodes
+listed in the [on chain settings]({% link docs/1.2/pbft/configuring-pbft.md
+%}#on-chain-settings-label) `sawtooth.consensus.pbft.members`.
 
-In a four-node network, for example, the first node (node 0) is the
-primary at view 0, the second node (node 1) is the primary at view 1,
-and so on. When the network gets to view 4, it will return to node 0 as
-the primary.
+In a four-node network, for example, the first node (node 0) is the primary at
+view 0, the second node (node 1) is the primary at view 1, and so on. When the
+network gets to view 4, it will return to node 0 as the primary.
 
-The algorithm uses the formula [p = v mod n]{.title-ref} to determine
-the next primary. In this formula, [p]{.title-ref} is the primary,
-[v]{.title-ref} is the view number, and [n]{.title-ref} is the total
-number of nodes in the network. For example, if a four-node network is
-at view 7, the formula [7 mod 4]{.title-ref} determines that node 3 is
-the primary.
+The algorithm uses the formula `p = v mod n` to determine the next primary. In
+this formula, `p` is the primary, `v` is the view number, and `n` is the total
+number of nodes in the network. For example, if a four-node network is at view
+7, the formula `7 mod 4` determines that node 3 is the primary.
 
-The Sawtooth PBFT algorithm changes the primary at regular intervals, as
-well as when the secondary nodes determine that the current primary is
-faulty. See `view-changing-mode-label`{.interpreted-text role="ref"} for
-a description of this process.
+The Sawtooth PBFT algorithm changes the primary at regular intervals, as well as
+when the secondary nodes determine that the current primary is faulty. See [View
+Changing Mode](#view-changing-mode-label) for a description of this process.
 
-## Sequence Numbers
+### Sequence Numbers
 
-In addition to moving through a series of views, the network moves
-through a series of [sequence numbers]{.title-ref}. In Sawtooth PBFT, a
-node\'s sequence number is the same as the block number of the next
-block in the chain. For example, a node that is on sequence number 10
-has already committed block 9 and is evaluating block 10.
+In addition to moving through a series of views, the network moves through a
+series of *sequence numbers*. In Sawtooth PBFT, a node's sequence number is the
+same as the block number of the next block in the chain. For example, a node
+that is on sequence number 10 has already committed block 9 and is evaluating
+block 10.
 
-Also, each message includes a sequence number that indicates which block
-the message is for. For example, a message with sequence number 10
-applies to block number 10.
+Also, each message includes a sequence number that indicates which block the
+message is for. For example, a message with sequence number 10 applies to block
+number 10.
 
-## Information Storage {#node-storage-label}
+### Information Storage {#node-storage-label}
 
 Each node stores several key pieces of information as part of its state:
 
--   List of PBFT member nodes in the network (from
-    `sawtooth.consensus.pbft.members`)
--   Current view number, which identifies the primary node
--   Current sequence number, which is also the number of the block being
-    processed
--   The current head of the chain
--   If in normal mode, the step of the algorithm it's on (see
-    `normal-mode-label`{.interpreted-text role="ref"})
--   Log of all blocks it has received
--   Log of all messages it has received
+- List of PBFT member nodes in the network (from
+  `sawtooth.consensus.pbft.members`)
+- Current view number, which identifies the primary node
+- Current sequence number, which is also the number of the block being processed
+- The current head of the chain
+- If in normal mode, the step of the algorithm it's on (see [Normal Mode](#normal-mode-label))
+- Log of all blocks it has received
+- Log of all messages it has received
 
-## Network Configuration {#network-config-label}
+### Network Configuration {#network-config-label}
 
 Sawtooth PBFT configures the network with on-chain settings, which are
 processed by the [Settings transaction
 processor](https://sawtooth.hyperledger.org/docs/core/releases/latest/transaction_family_specifications/settings_transaction_family.html)
 (or an equivalent).
 
-These settings list each node in the network, set the view-change
-interval (how often the primary changes), and specify other items such
-as the block publishing frequency, timeout periods, and message log
-size. For more information, see `configuring-pbft`{.interpreted-text
-role="doc"}.
+These settings list each node in the network, set the view-change interval (how
+often the primary changes), and specify other items such as the block publishing
+frequency, timeout periods, and message log size. For more information, see
+[Configuring PBFT]({% link docs/1.2/pbft/configuring-pbft.md %}).
 
-# Consensus Messages {#consensus-messages-label}
+## Consensus Messages {#consensus-messages-label}
 
 All PBFT consensus messages are serialized as [protobufs (protocol
 buffers)](https://developers.google.com/protocol-buffers/).
 
-When a node receives a new consensus message from another node, it
-parses the protobuf into a native Rust struct (`ParsedMessage`) that
-allows for easier handling of the message. After parsing, the node
-performs a series of checks to ensure the validity of the message:
+When a node receives a new consensus message from another node, it parses the
+protobuf into a native Rust struct (`ParsedMessage`) that allows for easier
+handling of the message. After parsing, the node performs a series of checks to
+ensure the validity of the message:
 
-1.  The `signer_id` of the PBFT message must match the `signer_id` of
-    the `PeerMessage` that contains it.
-2.  The message must be from a known PBFT member (the `signer_id` of the
-    PBFT message must be in the `sawtooth.consensus.pbft.members` list)
+1. The `signer_id` of the PBFT message must match the `signer_id` of the
+   `PeerMessage` that contains it.
+2. The message must be from a known PBFT member (the `signer_id` of the PBFT
+   message must be in the `sawtooth.consensus.pbft.members` list)
 
-The first check verifies that the PBFT message was created and signed by
-the node that it claims to be from. The `PeerMessage`, which acts as a
-wrapper for the PBFT message, contains a signature of the PBFT message
-and a `signer_id`; this signature and ID are verified by the validator
-to ensure that the contents of the `PeerMessage` are legitimate. PBFT
-then ensures that the `signer_id` of the PBFT message matches the one
-the validator used, which guarantees the origin of the PBFT message.
+The first check verifies that the PBFT message was created and signed by the
+node that it claims to be from. The `PeerMessage`, which acts as a wrapper for
+the PBFT message, contains a signature of the PBFT message and a `signer_id`;
+this signature and ID are verified by the validator to ensure that the contents
+of the `PeerMessage` are legitimate. PBFT then ensures that the `signer_id` of
+the PBFT message matches the one the validator used, which guarantees the origin
+of the PBFT message.
 
-The second check ensures that only nodes that are accepted members of
-the PBFT network are able to participate in the consensus process.
+The second check ensures that only nodes that are accepted members of the PBFT
+network are able to participate in the consensus process.
 
-Any messages that fail to parse or pass the required checks are ignored.
-If a message is successfully parsed and passes verification, it is
-passed to a handler for that specific message type (see
-`pbft-arch-message-types`{.interpreted-text role="ref"}), where it may
-go through further checks, be stored in the message log, or trigger some
-actions.
+Any messages that fail to parse or pass the required checks are ignored.  If a
+message is successfully parsed and passes verification, it is passed to a
+handler for that specific message type (see [Message
+Types]#pbft-arch-message-types)), where it may go through further checks, be
+stored in the message log, or trigger some actions.
 
-## Message Definitions
+### Message Definitions
 
 Most Sawtooth PBFT messages use the `PbftMessage` protobuf, as shown
 below. The `PbftNewView`, `PbftSignedVote`, and `PbftSeal` protobufs are
@@ -173,8 +156,8 @@ require different sets of data to be exchanged.
 
 Sawtooth PBFT also uses some of the message types defined in the
 consensus API, such as `BlockNew` and `BlockCommit`. These messages are
-called \"updates\" to distinguish them from the PBFT-specific messages.
-For more information on the consensus API\'s `Update` messages, see the
+called "updates" to distinguish them from the PBFT-specific messages.
+For more information on the consensus API's `Update` messages, see the
 [Consensus API
 RFC](https://github.com/hyperledger/sawtooth-rfcs/blob/master/text/0004-consensus-api.md#updates).
 
@@ -239,210 +222,191 @@ message PbftSeal {
 }
 ```
 
-## Message Types {#pbft-arch-message-types}
+### Message Types {#pbft-arch-message-types}
 
 A Sawtooth PBFT message has one of the following types:
 
--   `PrePrepare`: Sent by the primary node after it has published a new
-    block
--   `Prepare`: Broadcast by every node in the `Preparing` phase
--   `Commit`: Broadcast by every node in the `Committing` phase
--   `ViewChange`: Sent by any node that suspects that the primary is
-    faulty
--   `NewView`: Sent by the node that will be the new primary to complete
-    a view change
--   `Seal`: Proves that a block was committed after `2f + 1` nodes
-    agreed to commit it
--   `SealRequest`: Sent by a node that is requesting a consensus seal
-    for the block that was committed at a given sequence number
+- `PrePrepare`: Sent by the primary node after it has published a new block
+- `Prepare`: Broadcast by every node in the `Preparing` phase
+- `Commit`: Broadcast by every node in the `Committing` phase
+- `ViewChange`: Sent by any node that suspects that the primary is faulty
+- `NewView`: Sent by the node that will be the new primary to complete a view
+  change
+- `Seal`: Proves that a block was committed after `2f + 1` nodes agreed to
+  commit it
+- `SealRequest`: Sent by a node that is requesting a consensus seal for the
+  block that was committed at a given sequence number
 
-# PBFT Operation {#pbft-operation-label}
+## PBFT Operation {#pbft-operation-label}
 
-The Sawtooth PBFT algorithm starts with initialization, then operates in
-one of two modes:
+The Sawtooth PBFT algorithm starts with initialization, then operates in one of
+two modes:
 
--   `Normal mode <normal-mode-label>`{.interpreted-text role="ref"} for
-    processing blocks
--   `View Changing mode <view-changing-mode-label>`{.interpreted-text
-    role="ref"} for switching to a different primary node
+- [Normal mode](#normal-mode-label) for processing blocks
+- [View Changing mode](#view-changing-mode-label) for switching to a different
+  primary node
 
-::: note
-::: title
-Note
-:::
+> **Note**
+>
+> The original PBFT definition includes a checkpointing procedure that is
+> responsible for garbage collection of the log. Sawtooth PBFT does not
+> implement this checkpointing procedure; instead, it cleans the log
+> periodically during its normal operation. For more information, see
+> [Log Pruning](#log-pruning-label).
 
-The original PBFT definition includes a checkpointing procedure that is
-responsible for garbage collection of the log. Sawtooth PBFT does not
-implement this checkpointing procedure; instead, it cleans the log
-periodically during its normal operation. For more information, see
-`log-pruning-label`{.interpreted-text role="ref"}.
-:::
-
-## Initialization
+### Initialization
 
 When the Sawtooth PBFT consensus engine starts, it does the following:
 
--   Loads its configuration
--   Initializes its state and message log
--   Establishes timers and counters
+- Loads its configuration
+- Initializes its state and message log
+- Establishes timers and counters
 
-## Normal Mode {#normal-mode-label}
+### Normal Mode {#normal-mode-label}
 
-In Normal mode, nodes check blocks and approve them to be committed to
-the blockchain. The Sawtooth PBFT algorithm usually operates in normal
-mode unless a `view change <view-changing-mode-label>`{.interpreted-text
-role="ref"} is necessary.
+In Normal mode, nodes check blocks and approve them to be committed to the
+blockchain. The Sawtooth PBFT algorithm usually operates in normal mode unless a
+[view change](#view-changing-mode-label) is necessary.
 
-### Procedure
+#### Procedure
 
 The normal mode proceeds as follows:
 
-1.  All nodes begin in the `PrePreparing` phase; the purpose of this
-    phase is for the primary to publish a new block and endorse the
-    block with a `PrePrepare` message.
+1. All nodes begin in the `PrePreparing` phase; the purpose of this phase is for
+   the primary to publish a new block and endorse the block with a `PrePrepare`
+   message.
 
-    -   The primary node will send a request to its validator to
-        initialize a new block. After a configurable timeout (determined
-        by the `sawtooth.consensus.pbft.block_publishing_delay`
-        setting), the primary will send a request to the validator to
-        finalize the block and broadcast it to the network.
-    -   After receiving the block in a `BlockNew` update and ensuring
-        that the block is valid, all nodes will store the block in their
-        PBFT logs.
-    -   After receiving the `BlockNew` update, the primary will
-        broadcast a `PrePrepare` message for that block to all of the
-        nodes in the network. When the nodes receive this `PrePrepare`
-        message, they will make sure it is valid; if it is, they will
-        add it to their respective logs and move on to the `Preparing`
-        phase.
+   - The primary node will send a request to its validator to initialize a new
+     block. After a configurable timeout (determined by the
+     `sawtooth.consensus.pbft.block_publishing_delay` setting), the primary will
+     send a request to the validator to finalize the block and broadcast it to
+     the network.
+   - After receiving the block in a `BlockNew` update and ensuring that the
+     block is valid, all nodes will store the block in their PBFT logs.
+   - After receiving the `BlockNew` update, the primary will broadcast a
+     `PrePrepare` message for that block to all of the nodes in the network.
+     When the nodes receive this `PrePrepare` message, they will make sure it is
+     valid; if it is, they will add it to their respective logs and move on to
+     the `Preparing` phase.
 
-2.  In the `Preparing` phase, all secondary nodes (not the primary)
-    broadcast a `Prepare` message that matches the accepted `PrePrepare`
-    message. Each node will then add its own `Prepare` to its log, then
-    accept `Prepare` messages from other nodes and add them to its log.
-    Once a node has `2f + 1` `Prepare` messages in its log that match
-    the accepted `PrePrepare`, it will move on to the `Committing`
-    phase.
+2. In the `Preparing` phase, all secondary nodes (not the primary) broadcast a
+   `Prepare` message that matches the accepted `PrePrepare` message. Each node
+   will then add its own `Prepare` to its log, then accept `Prepare` messages
+   from other nodes and add them to its log.  Once a node has `2f + 1` `Prepare`
+   messages in its log that match the accepted `PrePrepare`, it will move on to
+   the `Committing` phase.
 
-3.  The `Committing` phase is similar to the `Preparing` phase; nodes
-    broadcast a `Commit` message to all nodes in the network, wait until
-    there are `2f + 1` `Commit` messages in their logs, then move on to
-    the `Finishing` phase. The only major difference between the
-    `Preparing` and `Committing` phases is that in the `Committing`
-    phase, the primary node is allowed to broadcast a message.
+3. The `Committing` phase is similar to the `Preparing` phase; nodes broadcast a
+   `Commit` message to all nodes in the network, wait until there are `2f + 1`
+   `Commit` messages in their logs, then move on to the `Finishing` phase. The
+   only major difference between the `Preparing` and `Committing` phases is that
+   in the `Committing` phase, the primary node is allowed to broadcast a
+   message.
 
-4.  Once in the `Finishing` phase, each node will tell its validator to
-    commit the block for which they have a matching `PrePrepare`,
-    `2f + 1` `Prepare` messages, and `2f + 1` `Commit` messages. The
-    node will then wait for a `BlockCommit` notification from its
-    validator to signal that the block has been successfully committed
-    to the chain. After receiving this confirmation, the node will
-    update its state as follows:
+4. Once in the `Finishing` phase, each node will tell its validator to commit
+   the block for which they have a matching `PrePrepare`, `2f + 1` `Prepare`
+   messages, and `2f + 1` `Commit` messages. The node will then wait for a
+   `BlockCommit` notification from its validator to signal that the block has
+   been successfully committed to the chain. After receiving this confirmation,
+   the node will update its state as follows:
 
-    -   Increment its sequence number by 1
-    -   Update its current chain head to the block that was just
-        committed
-    -   Reset its phase to `PrePreparing`
+   - Increment its sequence number by 1
+   - Update its current chain head to the block that was just committed
+   - Reset its phase to `PrePreparing`
 
-    Finally, the primary node will initialize a new block to start the
-    process all over again.
+   Finally, the primary node will initialize a new block to start the
+   process all over again.
 
-This diagram summarizes the four Normal mode phases, the messages sent,
-and the interactions with the validators. N1 is the primary node; N2,
-N3, and N4 are secondary nodes.
+This diagram summarizes the four Normal mode phases, the messages sent, and the
+interactions with the validators. N1 is the primary node; N2, N3, and N4 are
+secondary nodes.
 
 ![](images/normal_mode_procedure.png)
 
-### Log Pruning {#log-pruning-label}
+#### Log Pruning {#log-pruning-label}
 
-Sawtooth PBFT does not implement a checkpointing procedure (garbage
-collection of the log). Instead, each node cleans the log periodically
-during normal operation.
+Sawtooth PBFT does not implement a checkpointing procedure (garbage collection
+of the log). Instead, each node cleans the log periodically during normal
+operation.
 
-Log size is controlled on each node with the `--max_log_size` option
-when starting the PBFT consensus engine (see
-`cli-options-label`{.interpreted-text role="ref"}). When a block is
-committed, each node compares the size of its log against the maximum
-size. If the log exceeds this value, Sawtooth PBFT uses these rules to
-prune the log:
+Log size is controlled on each node with the `--max_log_size` option when
+starting the PBFT consensus engine (see [PBFT Command-Line Options]({% link
+docs/1.2/pbft/configuring-pbft.md %}#cli-options-label)). When a block is
+committed, each node compares the size of its log against the maximum size. If
+the log exceeds this value, Sawtooth PBFT uses these rules to prune the log:
 
--   Keep blocks and messages for the sequence number of the block that
-    was just committed, plus those for any higher (newer) sequence
-    numbers
--   Delete blocks and messages for all lower (earlier) sequence numbers
+- Keep blocks and messages for the sequence number of the block that was just
+  committed, plus those for any higher (newer) sequence numbers
+- Delete blocks and messages for all lower (earlier) sequence numbers
 
-## View Changing Mode {#view-changing-mode-label}
+### View Changing Mode {#view-changing-mode-label}
 
-A [view change]{.title-ref} switches to a different primary node. A node
-starts a new view change if any of the following occur:
+A *view change* switches to a different primary node. A node starts a new view
+change if any of the following occur:
 
--   The [idle timeout]{.title-ref} expires - when a node enters the
-    `PrePreparing` phase, it will start its idle timeout. If the node
-    receives a new block and a matching `PrePrepare` from the primary
-    for its current sequence number before the timeout expires, it will
-    stop the timeout; if not, the node will initiate a view change when
-    the timeout expires.
--   The [commit timeout]{.title-ref} expires - when a node enters the
-    `Preparing` phase, it will start its commit timeout. If the node is
-    able to move on to the `Finishing` phase and send a request to the
-    validator to commit the block before the timeout expires, it will
-    stop the timeout; if not, the node will initiate a view change when
-    the timeout expires.
--   The [view change timeout]{.title-ref} expires - when a node starts a
-    view change to view `v`, it will start a view change timeout. If the
-    node is able to complete the view change before the timeout expires,
-    it will stop the timeout; if not, it will initiate a new view change
-    to view `v + 1`.
--   Multiple `PrePrepare` messages are received for the same view and
-    sequence number but different blocks - this indicates the primary is
-    faulty, since this behavior is invalid.
--   A `Prepare` message is received from the primary - this indicates
-    the primary is faulty, since this behavior is invalid.
--   `f + 1` `ViewChange` messages are received for the same view - this
-    ensures that a node does not wait too long to start a view change;
-    since only `f` nodes (at most) can be faulty at any given time, if
-    more than `f` nodes decide to start a view change, other nodes can
-    safely join them to perform that view change.
+- The *idle timeout* expires - when a node enters the `PrePreparing` phase, it
+  will start its idle timeout. If the node receives a new block and a matching
+  `PrePrepare` from the primary for its current sequence number before the
+  timeout expires, it will stop the timeout; if not, the node will initiate a
+  view change when the timeout expires.
+- The *commit timeout* expires - when a node enters the `Preparing` phase, it
+  will start its commit timeout. If the node is able to move on to the
+  `Finishing` phase and send a request to the validator to commit the block
+  before the timeout expires, it will stop the timeout; if not, the node will
+  initiate a view change when the timeout expires.
+- The *view change timeout* expires - when a node starts a view change to view
+  `v`, it will start a view change timeout. If the node is able to complete the
+  view change before the timeout expires, it will stop the timeout; if not, it
+  will initiate a new view change to view `v + 1`.
+- Multiple `PrePrepare` messages are received for the same view and sequence
+  number but different blocks - this indicates the primary is faulty, since this
+  behavior is invalid.
+- A `Prepare` message is received from the primary - this indicates the primary
+  is faulty, since this behavior is invalid.
+- `f + 1` `ViewChange` messages are received for the same view - this ensures
+  that a node does not wait too long to start a view change; since only `f`
+  nodes (at most) can be faulty at any given time, if more than `f` nodes decide
+  to start a view change, other nodes can safely join them to perform that view
+  change.
 
 To start a view change, a node will do the following:
 
-1.  Update its mode to `ViewChanging(v)`, where `v` is the view the node
-    is changing to
-2.  Stop both the idle and and commit timeouts, since these are not
-    needed again until after the view change
-3.  Stop the view change timeout if it\'s been started; it will be
-    restarted with a new value later
-4.  Broadcast a `ViewChange` message for the new view
+1. Update its mode to `ViewChanging(v)`, where `v` is the view the node is
+   changing to
+2. Stop both the idle and commit timeouts, since these are not needed again
+   until after the view change
+3. Stop the view change timeout if it's been started; it will be restarted with
+   a new value later
+4. Broadcast a `ViewChange` message for the new view
 
-`ViewChange` messages are accepted and added to the log if they satisfy
-these criteria:
+`ViewChange` messages are accepted and added to the log if they satisfy these
+criteria:
 
--   They are for a later view than the node\'s current view
--   If the node is in the mode `ViewChanging(v)`, the view in the
-    message must be greater than or equal to `v`
+- They are for a later view than the node's current view
+- If the node is in the mode `ViewChanging(v)`, the view in the message must be
+  greater than or equal to `v`
 
-Once a node has received `2f + 1` `ViewChange` messages for the new
-view, it will start its view change timeout; this timeout ensures that
-the new primary starts the new view in a timely manner. The duration of
-the timeout is calculated based on a base duration (determined by the
-`sawtooth.consensus.pbft.view_change_duration` setting) using the
-formula: $(DesiredViewNumber - CurrentViewNumber) * ViewChangeDuration$.
+Once a node has received `2f + 1` `ViewChange` messages for the new view, it
+will start its view change timeout; this timeout ensures that the new primary
+starts the new view in a timely manner. The duration of the timeout is
+calculated based on a base duration (determined by the
+`sawtooth.consensus.pbft.view_change_duration` setting) using the formula:
+`(DesiredViewNumber - CurrentViewNumber) * ViewChangeDuration`.
 
-When the primary for the new view receives `2f + 1` `ViewChange`
-messages, it will broadcast a `NewView` message to the network,
-signifying that the view change is complete. As a proof that this view
-change is valid, the primary will include `2f + 1` signed `ViewChange`
-messages from other nodes in the `NewView` message (the primary\'s own
-\"vote\" is implicit), which will be validated by the other nodes.
+When the primary for the new view receives `2f + 1` `ViewChange` messages, it
+will broadcast a `NewView` message to the network, signifying that the view
+change is complete. As a proof that this view change is valid, the primary will
+include `2f + 1` signed `ViewChange` messages from other nodes in the `NewView`
+message (the primary's own "vote" is implicit), which will be validated by the
+other nodes.
 
-If a node receives the new primary\'s valid `NewView` message before its
-view change timeout expires, it will:
+If a node receives the new primary's valid `NewView` message before its view
+change timeout expires, it will:
 
-1.  Stop the view change timeout
-2.  Update its view to match the new value
-3.  Revert back to Normal mode
+1. Stop the view change timeout
+2. Update its view to match the new value
+3. Revert back to Normal mode
 
-However, if a node\'s view change timeout expires before it receives a
-`NewView`, it will stop the timeout and initiate a brand new view change
-for view `v + 1` (where `v` is the view it was attempting to change to
-before).
+However, if a node's view change timeout expires before it receives a `NewView`,
+it will stop the timeout and initiate a brand new view change for view `v + 1`
+(where `v` is the view it was attempting to change to before).

--- a/docs/1.2/pbft/configuring-pbft.md
+++ b/docs/1.2/pbft/configuring-pbft.md
@@ -1,15 +1,12 @@
----
-title: Configuring PBFT
----
+# Configuring PBFT
 
 Sawtooth PBFT is configured in two ways:
 
--   Local settings - Command-line (CLI) options when running the PBFT
-    executable or service
--   Network settings - On-chain settings that are defined for the
-    Sawtooth network
+- Local settings - Command-line (CLI) options when running the PBFT executable
+  or service
+- Network settings - On-chain settings that are defined for the Sawtooth network
 
-# PBFT Command-Line Options {#cli-options-label}
+## PBFT Command-Line Options {#cli-options-label}
 
 <!--
   Licensed under Creative Commons Attribution 4.0 International License
@@ -21,40 +18,55 @@ These options only affect the local behavior of a PBFT node, not the
 network as a whole. The PBFT consensus engine, `pbft-engine`, has the
 following command-line options:
 
--   | `-C, --connect CONNECT`
-    | (Optional; default `tcp://localhost:5050`)
-    | Connection endpoint for validator
+- `-C, --connect CONNECT`
 
--   | `-b, --exponential-retry-base BASE`
-    | (Optional; default 100 ms)
-    | Base timeout for exponential backoff used for validator requests
+  (Optional; default `tcp://localhost:5050`)
 
--   | `-m, --exponential-retry-max MAX`
-    | (Optional; default 60000 ms)
-    | Max timeout for exponential backoff used for validator requests
+  Connection endpoint for validator
 
--   | `-L, --log-config LOG_CONFIG`
-    | (Optional)
-    | Path to logging config file; if not present, console logging is
-      used
+- `-b, --exponential-retry-base BASE`
 
--   | `-l, --max-log-size MAX_LOG_SIZE`
-    | (Optional; default 10000 messages)
-    | How large the PBFT log is allowed to get before being pruned
+  (Optional; default 100 ms)
 
--   | `-s, --storage-location STORAGE_LOCATION`
-    | (Optional; default `memory`)
-    | Where to store PBFT\'s state: `memory` or `disk+/path/to/file`
+  Base timeout for exponential backoff used for validator requests
 
--   | `-u, --update-recv-timeout TIMEOUT`
-    | (Optional; default 10 ms)
-    | Timeout for receiving an update from the validator
+- `-m, --exponential-retry-max MAX`
 
--   | `-v`
-    | (Optional)
-    | Increase output verbosity
+  (Optional; default 60000 ms)
 
-# PBFT On-Chain Settings {#on-chain-settings-label}
+  Max timeout for exponential backoff used for validator requests
+
+- `-L, --log-config LOG_CONFIG`
+
+  (Optional)
+
+  Path to logging config file; if not present, console logging is used
+
+- `-l, --max-log-size MAX_LOG_SIZE`
+
+  (Optional; default 10000 messages)
+
+  How large the PBFT log is allowed to get before being pruned
+
+- `-s, --storage-location STORAGE_LOCATION`
+
+  (Optional; default `memory`)
+
+  Where to store PBFT\'s state: `memory` or `disk+/path/to/file`
+
+- `-u, --update-recv-timeout TIMEOUT`
+
+  (Optional; default 10 ms)
+
+  Timeout for receiving an update from the validator
+
+- `-v`
+
+  (Optional)
+
+  Increase output verbosity
+
+## PBFT On-Chain Settings {#on-chain-settings-label}
 
 Sawtooth PBFT includes on-chain settings for network-wide configuration
 on a Hyperledger Sawtooth network. These settings affect how the whole
@@ -63,54 +75,56 @@ The [Settings transaction
 processor](https://sawtooth.hyperledger.org/docs/core/releases/latest/transaction_family_specifications/settings_transaction_family.html)
 (or an equivalent) is required to process these settings.
 
-::: tip
-::: title
-Tip
-:::
+> ** Tip **
+>
+> To display the existing settings, use [sawtooth settings
+> list](https://sawtooth.hyperledger.org/docs/core/releases/latest/cli/sawtooth.html#sawtooth-settings-list).
+> To change a setting, use [sawset proposal
+> create](https://sawtooth.hyperledger.org/docs/core/releases/latest/cli/sawset.html#sawset-proposal-create).
+> This command requires a signing key (the `--key` option) that specifies the
+> public key of a user or validator that has permission to change settings. See
+> `sawtooth.identity.allowed_keys` in [Configuring Validator and Transactor
+> Permissions](https://sawtooth.hyperledger.org/docs/core/releases/latest/sysadmin_guide/configuring_permissions.html).
 
-To display the existing settings, use [sawtooth settings
-list](https://sawtooth.hyperledger.org/docs/core/releases/latest/cli/sawtooth.html#sawtooth-settings-list).
+- `sawtooth.consensus.pbft.block_publishing_delay`
 
-To change a setting, use [sawset proposal
-create](https://sawtooth.hyperledger.org/docs/core/releases/latest/cli/sawset.html#sawset-proposal-create).
-This command requires a signing key (the `--key` option) that specifies
-the public key of a user or validator that has permission to change
-settings. See `sawtooth.identity.allowed_keys` in [Configuring Validator
-and Transactor
-Permissions](https://sawtooth.hyperledger.org/docs/core/releases/latest/sysadmin_guide/configuring_permissions.html).
-:::
+  (Optional; default 1000 ms)
 
--   | `sawtooth.consensus.pbft.block_publishing_delay`
-    | (Optional; default 1000 ms)
-    | How often to try to publish a block.
+  How often to try to publish a block.
 
--   | `sawtooth.consensus.pbft.commit_timeout`
-    | (Optional; default 10000 ms)
-    | How long to wait (after Pre-Preparing) for the node to commit the
-      block
-    | before determining that the primary node is faulty.
+- `sawtooth.consensus.pbft.commit_timeout`
 
--   | `sawtooth.consensus.pbft.forced_view_change_interval`
-    | (Optional; default 100 blocks)
-    | Number of blocks to commit before forcing a view change.
+  (Optional; default 10000 ms)
 
--   | `sawtooth.consensus.pbft.idle_timeout`
-    | (Optional; default 30000 ms)
-    | How long to wait for the next `BlockNew` and `PrePrepare` messages
-    | before determining that the primary node is faulty. The idle
-      timeout must be
-    | longer than the block publishing delay.
+  How long to wait (after Pre-Preparing) for the node to commit the block before
+  determining that the primary node is faulty.
 
--   | `sawtooth.consensus.pbft.members`
-    | (Required)
-    | List of validator public keys for the member nodes in the PBFT
-      network,
-    | as a comma-separated list (in a JSON-formatted string):
-    | `[public-key-1, public-key-2, ..., public-key-n]`
+- `sawtooth.consensus.pbft.forced_view_change_interval`
 
--   | `sawtooth.consensus.pbft.view_change_duration`
-    | (Optional; default 5000 ms)
-    | How long to wait for a valid `NewView` message before starting the
-      next
-    | view change. For more information, see
-      `view-changing-mode-label`{.interpreted-text role="ref"}.
+  (Optional; default 100 blocks)
+
+  Number of blocks to commit before forcing a view change.
+
+- `sawtooth.consensus.pbft.idle_timeout`
+
+  (Optional; default 30000 ms)
+
+  How long to wait for the next `BlockNew` and `PrePrepare` messages before
+  determining that the primary node is faulty. The idle timeout must be longer
+  than the block publishing delay.
+
+- `sawtooth.consensus.pbft.members`
+
+  (Required)
+
+  List of validator public keys for the member nodes in the PBFT network, as a
+  comma-separated list (in a JSON-formatted string): `[public-key-1, public-key-2,
+  ..., public-key-n]`
+
+- `sawtooth.consensus.pbft.view_change_duration`
+
+  (Optional; default 5000 ms)
+
+  How long to wait for a valid `NewView` message before starting the next view
+  change. For more information, see [View Changing Mode]({% link
+  docs/1.2/pbft/architecture.md %}#view-changing-mode-label).

--- a/docs/1.2/pbft/glossary.md
+++ b/docs/1.2/pbft/glossary.md
@@ -1,14 +1,10 @@
----
-title: Glossary
----
-
-::: glossary
+# Glossary
 
 Block
 
 :   Part of the
     [blockchain](https://en.wikipedia.org/wiki/Block%20chain) that
-    contains one or more operations (called [transactions]{.title-ref})
+    contains one or more operations (called *transactions*)
     and a link to the previous block.
 
 Client
@@ -22,7 +18,7 @@ Consensus API
 
 :   Sawtooth component that abstracts consensus-related interactions
     between the validator and a consensus engine. The consensus API
-    allows [dynamic consensus]{.title-ref}, a feature that allows a
+    allows *dynamic consensus*, a feature that allows a
     choice of consensus for a Sawtooth network.
 
 Consensus engine
@@ -37,21 +33,20 @@ Consensus seal
 
 Leader
 
-:   See `primary node`{.interpreted-text role="term"}.
+:   See [primary node](#primary-node)
 
 Member node
 
-:   Sawtooth node that participates in PBFT consensus. Membership is
-    controlled by the on-chain setting
-    `sawtooth.consensus.pbft.members`. Each member node is either a
-    `primary node`{.interpreted-text role="term"} or a
-    `secondary node`{.interpreted-text role="term"}.
+:   Sawtooth node that participates in PBFT consensus. Membership is controlled
+    by the on-chain setting `sawtooth.consensus.pbft.members`. Each member node
+    is either a [primary node](#primary-node) or a [secondary
+    node](#secondary-node).
 
 Message
 
 :   Consensus-related information that nodes send to each other. For
-    more information, see `consensus-messages-label`{.interpreted-text
-    role="ref"}.
+    more information, see [Consensus Messages]({% link
+    docs/1.2/pbft/architecture.md %}#consensus-messages-label).
 
 Node
 
@@ -61,35 +56,32 @@ Node
 
     The [original PBFT
     paper](http://pmg.csail.mit.edu/papers/osdi99.pdf) uses the terms
-    [server]{.title-ref} or [replica]{.title-ref} instead of
-    [node]{.title-ref}.
+    *server* or *replica* instead of *node*.
 
-Primary node
+Primary node <a name="primary-node"></a>
 
 :   Node that directs the consensus process for the network. (The other
     nodes in the network participate as secondary nodes.) The primary
     node creates each block and publishes it to the network, then starts
     the consensus process for the block.
 
-Secondary node
+Secondary node <a name="secondary-node"></a>
 
 :   Auxiliary node used for consensus. A Sawtooth network using PBFT
-    consensus has one `primary node`{.interpreted-text role="term"}; all
+    consensus has one [primary node](#primary-node); all
     other nodes are secondary nodes.
 
     The [original PBFT
     paper](http://pmg.csail.mit.edu/papers/osdi99.pdf) uses the term
-    [backup]{.title-ref} instead of [secondary node]{.title-ref}.
+    *backup* instead of *secondary node*.
 
 Transaction processor
 
-:   Sawtooth component that validates transactions and updates state
-    based on rules defined by the associated [transaction
-    family]{.title-ref}. (These rules specify the business logic, also
-    called a [smart contract]{.title-ref}, for the transaction
-    processor.) For more information, see [\"Transaction Family
-    Specifications\" in the Hyperledger Sawtooth
-    documentation](https://sawtooth.hyperledger.org/docs/core/releases/latest/transaction_family_specifications.html).
+:   Sawtooth component that validates transactions and updates state based on
+    rules defined by the associated *transaction family*. (These rules specify
+    the business logic, also called a *smart contract*, for the transaction
+    processor.) For more information, see [Transaction Family Specifications]({%
+    link docs/1.2/transaction_family_specification/index.md %}).
 
 Validator
 
@@ -102,9 +94,9 @@ View
 :   The period of time when the current primary node is in charge. The
     view changes at regular intervals (controlled by the on-chain
     setting `sawtooth.consensus.pbft.forced_view_change_interval`), and
-    when the primary node is deemed faulty. For more information, see
-    `view-changes-choosing-primary-label`{.interpreted-text role="ref"}.
-:::
+    when the primary node is deemed faulty. For more information, see [View
+    Changes: Choosing a New Primary]({% link docs/1.2/pbft/architecture.md
+    %}#view-changes-choosing-primary-label).
 
 <!--
   Licensed under Creative Commons Attribution 4.0 International License

--- a/docs/1.2/pbft/installing-and-running-pbft.md
+++ b/docs/1.2/pbft/installing-and-running-pbft.md
@@ -1,107 +1,96 @@
----
-title: Installing and Testing PBFT
----
+# Installing and Testing PBFT
 
-This procedure describes how to install PBFT, start a four-node network
-in Docker containers, and run a basic liveness test.
+This procedure describes how to install PBFT, start a four-node network in
+Docker containers, and run a basic liveness test.
 
-**Prerequisites:** [Docker and Docker Compose](https://www.docker.com/)
-must be installed.
+**Prerequisites:** [Docker and Docker Compose](https://www.docker.com/) must be
+installed.
 
-1.  Clone the PBFT repository.
+1. Clone the PBFT repository.
 
-    > ``` console
-    > $ git clone https://github.com/hyperledger/sawtooth-pbft.git
-    > ```
+    ```console
+    $ git clone https://github.com/hyperledger/sawtooth-pbft.git
+    ```
 
-2.  Run the following commands to install the dependencies for PBFT and
-    connect to the interactive shell container, `sawtooth-dev-pbft`.
+2. Run the following commands to install the dependencies for PBFT and
+   connect to the interactive shell container, `sawtooth-dev-pbft`.
 
-    > ``` console
-    > $ cd sawtooth-pbft
-    > $ docker build . -f Dockerfile -t sawtooth-dev-pbft
-    > $ docker run -v $(pwd):/project/sawtooth-pbft -it sawtooth-dev-pbft bash
-    > ```
+   ```console
+   $ cd sawtooth-pbft
+   $ docker build . -f Dockerfile -t sawtooth-dev-pbft
+   $ docker run -v $(pwd):/project/sawtooth-pbft -it sawtooth-dev-pbft bash
+    ```
 
-    ::: tip
-    ::: title
-    Tip
-    :::
+   > *Tip*
+   >
+   > If you have already configured a `cargo-registry` Docker volume, use the
+   > following `docker run` command to speed up the build time in the next step.
+   >
+   > ``` console
+   > $ docker run -v $(pwd):/project/sawtooth-pbft \
+   > -v cargo-registry:/root/.cargo/registry \
+   > -it sawtooth-dev-pbft bash
+   > ```
 
-    If you have already configured a `cargo-registry` Docker volume, use
-    the following `docker run` command to speed up the build time in the
-    next step.
+3. Build the PBFT project.
 
-    > ``` console
-    > $ docker run -v $(pwd):/project/sawtooth-pbft \
-    > -v cargo-registry:/root/.cargo/registry \
-    > -it sawtooth-dev-pbft bash
-    > ```
-    :::
+   ```console
+   $ cargo build
+   ```
 
-3.  Build the PBFT project.
+4. After the project has finished building, exit the `sawtooth-dev-pbft` shell
+   container.
 
-    > ``` console
-    > $ cargo build
-    > ```
+5. Run the PBFT test script on your host system from the
+   `sawtooth-pbft` directory.
 
-4.  After the project has finished building, exit the
-    `sawtooth-dev-pbft` shell container.
+   ``` console
+   % bin/run_docker_test tests/test_liveness.yaml
+   ```
 
-5.  Run the PBFT test script on your host system from the
-    `sawtooth-pbft` directory.
+   This command builds several Docker images, starts up a network of four
+   Sawtooth nodes with PBFT consensus, then goes through a liveness test of 55
+   blocks, as defined in the Docker Compose file `test_liveness.yaml`. The
+   default log level is `INFO`, so the test script displays a large amount of
+   information as it executes.
 
-    > ``` console
-    > % bin/run_docker_test tests/test_liveness.yaml
-    > ```
+   Tips:
 
-    This command builds several Docker images, starts up a network of
-    four Sawtooth nodes with PBFT consensus, then goes through a
-    liveness test of 55 blocks, as defined in the Docker Compose file
-    `test_liveness.yaml`. The default log level is `INFO`, so the test
-    script displays a large amount of information as it executes.
+   - This script has several options, such as `--clean`, `--no-build`, and
+     `--timeout`. For more information, execute `run_docker_test --help`.
+   - To run a different test, specify a different Compose file for
+     `run_docker_test`. The `sawtooth-pbft/tests/` directory includes several
+     Docker Compose files for testing, such as `grafana.yaml`, `client.yaml`,
+     and `pbft_unit_tests.yaml`.
+   - To adjust the [on chain settings]({% link
+     docs/1.2/pbft/configuring-pbft.md %}#on-chain-settings-label), edit the
+     testing Compose file and change the `sawset proposal create` parameter for
+     the genesis validator container (`validator-0`). This example shows the
+     settings in `test_liveness.yaml`:
 
-    Tips:
+   ```yaml
+   validator-0
+      ...
+      sawset proposal create \
+        ...
+        sawtooth.consensus.algorithm.name=pbft \
+        sawtooth.consensus.algorithm.version=1.0 \
+        sawtooth.consensus.pbft.members=\\['\\\"'$$(cat /etc/sawtooth/keys/validator.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-1.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-2.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-3.pub)'\\\"'\\] \
+       ...
+    ```
 
-    -   This script has several options, such as `--clean`,
-        `--no-build`, and `--timeout`. For more information, execute
-        `run_docker_test --help`.
-    -   To run a different test, specify a different Compose file for
-        `run_docker_test`. The `sawtooth-pbft/tests/` directory includes
-        several Docker Compose files for testing, such as
-        `grafana.yaml`, `client.yaml`, and `pbft_unit_tests.yaml`.
-    -   To adjust the `<on-chain-settings-label>`{.interpreted-text
-        role="ref"}, edit the testing Compose file and change the
-        `sawset proposal create` parameter for the genesis validator
-        container (`validator-0`). For more information, see
-        `on-chain-settings-label`{.interpreted-text role="ref"}. This
-        example shows the settings in `test_liveness.yaml`:
+    - To adjust the [CLI options]({% link docs/1.2/pbft/configuring-pbft.md
+      %}#cli-options-label), edit the testing Compose file and change the
+      options used with the `pbft-engine` command for each PBFT container. This
+      example shows the options in `test_liveness.yaml` for the `pbft-0`
+      container:
 
-    > ``` yaml
-    > validator-0
-    >    ...
-    >    sawset proposal create \
-    >      ...
-    >      sawtooth.consensus.algorithm.name=pbft \
-    >      sawtooth.consensus.algorithm.version=1.0 \
-    >      sawtooth.consensus.pbft.members=\\['\\\"'$$(cat /etc/sawtooth/keys/validator.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-1.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-2.pub)'\\\"','\\\"'$$(cat /etc/sawtooth/keys/validator-3.pub)'\\\"'\\] \
-    >    ...
-    > ```
-
-    -   To adjust the `<cli-options-label>`{.interpreted-text
-        role="ref"}, edit the testing Compose file and change the
-        options used with the `pbft-engine` command for each PBFT
-        container. For more information, see
-        `<cli-options-label>`{.interpreted-text role="ref"}. This
-        example shows the options in `test_liveness.yaml` for the
-        `pbft-0` container:
-
-        ``` yaml
-        pbft-0
-          ...
-          command: ./target/debug/pbft-engine --connect tcp://validator-0:5050 -vv
-          ...
-        ```
+      ```yaml
+      pbft-0
+        ...
+        command: ./target/debug/pbft-engine --connect tcp://validator-0:5050 -vv
+        ...
+      ```
 
 <!--
   Licensed under Creative Commons Attribution 4.0 International License

--- a/docs/1.2/pbft/introduction-to-sawtooth-pbft.md
+++ b/docs/1.2/pbft/introduction-to-sawtooth-pbft.md
@@ -1,26 +1,24 @@
----
-title: Introduction
----
+# Introduction
 
 Sawtooth PBFT is a consensus engine for Hyperledger Sawtooth that
 provides practical Byzantine fault tolerance.
 
 PBFT is a voting-based consensus algorithm that is:
 
--   Byzantine fault tolerant: Network [liveness and
-    safety](https://en.wikipedia.org/wiki/Liveness#Liveness_and_safety)
-    are guaranteed even when some nodes are faulty or malicious, as long
-    as a minimum percentage of nodes are connected, working properly,
-    and behaving honestly.
--   Non-forking: Blocks committed by nodes are final, unlike
-    lottery-style consensus algorithms such as Proof of Work (PoW) or
-    Proof of Elapsed Time (PoET).
--   Leader-based: A [primary node]{.title-ref} is responsible for
-    producing candidate blocks; [secondary nodes]{.title-ref} vote on
-    the blocks produced by the primary. The leader changes in a
-    round-robin (circular) order.
--   Communication-intensive: Nodes send many messages to reach
-    consensus, commit blocks, and maintain a healthy leader node.
+- Byzantine fault tolerant: Network [liveness and
+  safety](https://en.wikipedia.org/wiki/Liveness#Liveness_and_safety)
+  are guaranteed even when some nodes are faulty or malicious, as long
+  as a minimum percentage of nodes are connected, working properly,
+  and behaving honestly.
+- Non-forking: Blocks committed by nodes are final, unlike
+  lottery-style consensus algorithms such as Proof of Work (PoW) or
+  Proof of Elapsed Time (PoET).
+- Leader-based: A *primary node* is responsible for
+  producing candidate blocks; *secondary nodes* vote on
+  the blocks produced by the primary. The leader changes in a
+  round-robin (circular) order.
+- Communication-intensive: Nodes send many messages to reach
+  consensus, commit blocks, and maintain a healthy leader node.
 
 A Sawtooth PBFT network does not support open enrollment, but nodes can
 be added and removed by an administrator. Full peering is required (all
@@ -32,22 +30,18 @@ Byzantine Fault
 Tolerance](https://www.usenix.org/legacy/events/osdi99/full_papers/castro/castro_html/castro.html)
 by Miguel Castro and Barbara Liskov. This implementation has been
 adapted for use in a blockchain context; it includes extensions such as
-regular [view changes]{.title-ref} (leader changes) and a [consensus
-seal]{.title-ref} to verify block finality.
+regular *view changes* (leader changes) and a *consensus
+seal* to verify block finality.
 
-::: note
-::: title
-Note
-:::
-
-Sawtooth PBFT uses the terms \"primary\" and \"secondary\" to refer to
-the role of nodes in the network, which differs slightly from the
-terminology used in the PBFT paper.
-
--   \"Primary\" is synonymous with \"leader\"
--   \"Secondary\" is synonymous with \"follower\" and \"backup\"
--   \"Node\" is synonymous with \"server\" and \"replica\"
-:::
+> **Note**
+>
+> Sawtooth PBFT uses the terms "primary" and "secondary" to refer to
+> the role of nodes in the network, which differs slightly from the
+> terminology used in the PBFT paper.
+>
+> - "Primary" is synonymous with "leader"
+> - "Secondary" is synonymous with "follower" and "backup"
+> - "Node" is synonymous with "server" and "replica"
 
 For implementation details, see the [rustdoc for Sawtooth
 PBFT](https://sawtooth.hyperledger.org/docs/pbft/nightly/master/pbft_doc/pbft_engine/index.html).

--- a/docs/1.2/pbft/using-pbft-consensus.md
+++ b/docs/1.2/pbft/using-pbft-consensus.md
@@ -1,51 +1,48 @@
----
-title: Using PBFT Consensus
----
+# Using PBFT Consensus
 
 Sawtooth PBFT consensus provides Byzantine fault tolerance for a network
 with restricted membership. It has the following requirements:
 
--   A network using PBFT consensus must have at least four nodes. A
-    network with fewer nodes will fail; a new network with less than
-    four nodes will not start.
--   A PBFT network must be fully peered; that is, all nodes must be
-    directly connected to all other nodes. Static peering is
-    recommended.
--   Each node on the network must install and run the PBFT consensus
-    engine.
-    -   Package: `sawtooth-pbft-engine`
-    -   Executable: `pbft-engine`
-    -   Service: `sawtooth-pbft-engine.service`
--   Each node must run the Settings transaction processor (or an
-    equivalent) to handle the PBFT and Sawtooth on-chain settings.
--   The genesis block must specify the PBFT consensus engine name and
-    version, using the on-chain settings
-    `sawtooth.consensus.algorithm.name` and
-    `sawtooth.consensus.algorithm.version`.
-    -   The PBFT consensus engine name is `pbft`.
-    -   The version number is in the file `sawtooth-pbft/Cargo.toml`
-        (see the
-        [sawtooth-pbft](https://github.com/hyperledger/sawtooth-pbft/)
-        repository) as `version = "{major}.{minor}.{patch}"`. Use only
-        the first two digits (major and minor release numbers); omit the
-        patch number. For example, if the version is 1.0.4, use `1.0`
-        for the version setting.
--   The on-chain configuration setting `sawtooth.consensus.pbft.members`
-    must list all PBFT member nodes in the network. For more
-    information, see `on-chain-settings-label`{.interpreted-text
-    role="ref"}.
+- A network using PBFT consensus must have at least four nodes. A
+  network with fewer nodes will fail; a new network with less than
+  four nodes will not start.
+- A PBFT network must be fully peered; that is, all nodes must be
+  directly connected to all other nodes. Static peering is
+  recommended.
+- Each node on the network must install and run the PBFT consensus
+  engine.
+  - Package: `sawtooth-pbft-engine`
+  - Executable: `pbft-engine`
+  - Service: `sawtooth-pbft-engine.service`
+- Each node must run the Settings transaction processor (or an
+  equivalent) to handle the PBFT and Sawtooth on-chain settings.
+- The genesis block must specify the PBFT consensus engine name and
+  version, using the on-chain settings
+  `sawtooth.consensus.algorithm.name` and
+  `sawtooth.consensus.algorithm.version`.
+  - The PBFT consensus engine name is `pbft`.
+  - The version number is in the file `sawtooth-pbft/Cargo.toml`
+    (see the
+    [sawtooth-pbft](https://github.com/hyperledger/sawtooth-pbft/)
+    repository) as `version = "{major}.{minor}.{patch}"`. Use only
+    the first two digits (major and minor release numbers); omit the
+    patch number. For example, if the version is 1.0.4, use `1.0`
+    for the version setting.
+- The on-chain configuration setting `sawtooth.consensus.pbft.members`
+  must list all PBFT member nodes in the network. For more
+  information, see [PBFT On Chain Settings]({% link docs/1.2/pbft/configuring-pbft.md %}#on-chain-settings-label).
 
 For the procedure to configure PBFT, see the Hyperledger Sawtooth
 documentation:
 
--   Developers: [Creating a Sawtooth
-    Network](https://sawtooth.hyperledger.org/docs/core/releases/latest/app_developers_guide/creating_sawtooth_network.html)
-    shows how to create a test network with PBFT consensus for an
-    application development environment.
--   Sawtooth administrators: [Setting Up a Sawtooth
-    Node](https://sawtooth.hyperledger.org/docs/core/releases/latest/sysadmin_guide/setting_up_sawtooth_poet-sim.html)
-    explains how to create a Sawtooth network with PBFT consensus, plus
-    how to add or remove nodes for an existing network.
+- Developers: [Creating a Sawtooth
+  Network]({% link docs/1.2/app_developers_guide/creating_sawtooth_network.md %})
+  shows how to create a test network with PBFT consensus for an
+  application development environment.
+- Sawtooth administrators: [Setting Up a Sawtooth
+  Node](https://sawtooth.hyperledger.org/docs/core/releases/latest/sysadmin_guide/setting_up_sawtooth_poet-sim.html)
+  explains how to create a Sawtooth network with PBFT consensus, plus
+  how to add or remove nodes for an existing network.
 
 <!--
   Licensed under Creative Commons Attribution 4.0 International License


### PR DESCRIPTION
This change fixes a number of markdown issues and updates links to use liquid links.
