### PR TITLE
Caleb hill faq refresh by file

### DIFF
--- a/faq/client.md
+++ b/faq/client.md
@@ -1,17 +1,19 @@
-\-\--layout: default hide: true tags: \[faq\] title: Sawtooth FAQ -
-Client permalink: /faq/client/ \# Copyright (c) 2018, Intel Corporation.
-\# Licensed under Creative Commons Attribution 4.0 International License
-\# <https://creativecommons.org/licenses/by/4.0/> \-\--Sawtooth FAQ:
-Client ====================
+---
+layout: default
+hide: true
+tags: [faq]
+title: Sawtooth FAQ - Client
+permalink: /faq/client/
+# Copyright (c) 2018, Intel Corporation.
+# Licensed under Creative Commons Attribution 4.0 International License
+# <https://creativecommons.org/licenses/by/4.0/>
+---
 
-::: mininav
+# Sawtooth FAQ: Client
+
 [PREVIOUS](/faq/consensus/) [TOP](/faq/) [NEXT](/faq/rest/)
-:::
 
-::: contents
-:::
-
-# What is a Sawtooth Client?
+## What is a Sawtooth Client?
 
 It is an application that communicates with the Sawtooth Validator,
 usually using the REST API. The application is Transaction
@@ -19,7 +21,7 @@ Family-specific and may come in various forms, such as a CLI, BUI
 (browser/web app), GUI, or background daemon. The client may be written
 in any language supported by the Sawtooth SDK.
 
-# What languages does the Sawtooth Client SDK support?
+## What languages does the Sawtooth Client SDK support?
 
 JavaScript, Python 3, and Rust. Others are in the process of being
 added: Java and C++. A SDK for Microsoft .NET is also available from
@@ -32,13 +34,13 @@ more than others. See this chart of Sawtooth SDK support:
 For more information, see the Sawtooth SDK Reference at
 <https://sawtooth.hyperledger.org/docs/core/releases/latest/sdks.html>
 
-# Does Sawtooth have a .NET SDK?
+## Does Sawtooth have a .NET SDK?
 
 Yes, there is a Sawtooth SDK for .NET Core described here:
 <https://tomislav.tech/2018-03-02-sawtooth-sdk-net-core/> The source is
 here: <https://github.com/hyperledger/sawtooth-sdk-dotnet>
 
-# When would you want to develop without the Sawtooth SDK?
+## When would you want to develop without the Sawtooth SDK?
 
 You should use the SDK whenever possible for your language. If your
 preferred development language does not have a SDK, or if the SDK is
@@ -46,24 +48,24 @@ incomplete for something you need, then develop without a SDK. For
 details, see
 <https://sawtooth.hyperledger.org/docs/core/releases/latest/app_developers_guide/no_sdk.html>
 
-# What does the client do to send a transaction?
+## What does the client do to send a transaction?
 
 It encodes the TF-specific payload (which could be anything, but defined
 by the TF) in Base64, signs the transaction using ECDSA with curve
 secp256k1, and generates a deterministic state address.
 
-# What is the nonce used for in the transaction header?
+## What is the nonce used for in the transaction header?
 
 A nonce is a one-time use number (never repeated). Typically a random
 number is used for a nonce. A nonce in this case guarantees against
 replay attacks by making transactions unique.
 
-# What does this error mean:
+## What does this error mean:
 
 `validator | [... DEBUG signature_verifier] transaction signature invalid for txn: ...`?
 The client submitted a transaction with an invalid signature.
 
-# What are the various batch_statuses REST API result values?
+## What are the various batch_statuses REST API result values?
 
 -   `PENDING` - batch validation has started on this validator. This
     ends when the batch is either committed or invalidated
@@ -74,7 +76,7 @@ The client submitted a transaction with an invalid signature.
     currently being validated by this validator, not in the blockchain,
     and not in this validator\'s invalid cache
 
-# What does an INVALID batch status mean?
+## What does an INVALID batch status mean?
 
 I means the transaction batch was processed by the Transaction
 Processor, but the TP marked it as invalid. The INVALID batch
@@ -82,7 +84,7 @@ information is not stored on the blockchain. Validators will keep a
 local cache of invalid batch info around for awhile (I think 10
 minutes), so clients can query it, but that data is ephemeral.
 
-# What does it mean if a batch status result remains PENDING?
+## What does it mean if a batch status result remains PENDING?
 
 It means processing has not completed on the batch. If it stays that
 way, it means the transaction batch never reached the Transaction
@@ -91,13 +93,13 @@ the TP to appear online. The TP may have died or may have never started.
 Or the validator failed the PoET Z Test (z-tested out) because it was
 winning too frequently.
 
-# Can I use partial address prefixes (say the 6-character prefix) in a transaction\'s input or output list?
+## Can I use partial address prefixes (say the 6-character prefix) in a transaction\'s input or output list?
 
 Yes. You can use full addresses or partial addresses or empty (no
 address). The full addresses are preferred as this allows the parallel
 scheduler to process non-conflicting transactions in parallel.
 
-# How do I debug a Sawtooth client?
+## How do I debug a Sawtooth client?
 
 -   Add debug messages (such as `print("Action = {}".format(action))` in
     Python).
@@ -108,13 +110,13 @@ scheduler to process non-conflicting transactions in parallel.
     logging information in the Sawtooth REST API and Validator
     components.
 
-# How do I delete or change a specific value in state?
+## How do I delete or change a specific value in state?
 
 Use the `delete_state` in the SDK to delete a specific state variable.
 The data will remain in previously-created blocks (which are immutable),
 but will not be in the current blockchain state.
 
-# How can a Sawtooth client access a validator on another machine?
+## How can a Sawtooth client access a validator on another machine?
 
 By default, the REST API listens to client requests on localhost
 (127.0.0.1) and is not accessible from a client on another machine. To
@@ -123,7 +125,7 @@ change this, edit file /etc/sawtooth/rest_api.toml\` (copy from
 `bind = ["10.1.1.2:8008"]` where you change `10.1.1.2` to your IP
 address or hostname.
 
-# How do I use the Rust SDK in MS Windows?
+## How do I use the Rust SDK in MS Windows?
 
 Colin McCullough gives these steps: [Colin
 McCullough](https://github.com/colincmcc) gives these steps:
@@ -161,8 +163,6 @@ Until Rust and the RustSDK are a bit more mature, I still recommend
 using a Docker container for development to avoid any MS Windows
 troubles. You can reach me at <hello@colinmac.me> with any questions.
 
-::: mininav
 [PREVIOUS](/faq/consensus/) [TOP](/faq/) [NEXT](/faq/rest/)
-:::
 
 © Copyright 2018, Intel Corporation.

--- a/faq/consensus.md
+++ b/faq/consensus.md
@@ -1,18 +1,19 @@
-\-\--layout: default hide: true tags: \[faq\] title: Sawtooth FAQ -
-Consensus Algorithms permalink: /faq/consensus/ \# Copyright (c) 2018,
-Intel Corporation. \# Licensed under Creative Commons Attribution 4.0
-International License \# <https://creativecommons.org/licenses/by/4.0/>
-\-\--Sawtooth FAQ: Consensus Algorithms (including PoET)
-===================================================
+---
+layout: default
+hide: true
+tags: [faq]
+title: Sawtooth FAQ - Consensus Algorithms
+permalink: /faq/consensus/
+# Copyright (c) 2018, Intel Corporation.
+# Licensed under Creative Commons Attribution 4.0 International License
+# <https://creativecommons.org/licenses/by/4.0/>
+---
 
-::: mininav
+# Sawtooth FAQ: Consensus Algorithms (including PoET)
+
 [PREVIOUS](/faq/validator/) [TOP](/faq/) [NEXT](/faq/client/)
-:::
 
-::: contents
-:::
-
-# What consensus algorithms does Sawtooth support?
+## What consensus algorithms does Sawtooth support?
 
 Devmode (name \"Devmode\", version 0.1)
 
@@ -49,7 +50,7 @@ Raft (name \"raft\", version 0.1)
     is CFT, not BFT. Also Raft does not fork. For Sawtooth Raft is new
     and still being stabilized.
 
-# Will Sawtooth support more consensus algorithms in the future?
+## Will Sawtooth support more consensus algorithms in the future?
 
 Yes. With pluggable consensus, the idea is to have a meaningful set of
 consensus algorithms so the \"best fit\" can be applied to an
@@ -59,31 +60,31 @@ stabilized. Others are being planned.
 REMME.io has independently implemented Algorand Byzantine Agreement on
 Sawtooth.
 
-# Where is Raft documented?
+## Where is Raft documented?
 
 <https://sawtooth.hyperledger.org/docs/raft/nightly/master/> To use,
 basically set `sawtooth.consensus.algorithm` to `raft` and
 `sawtooth.consensus.raft.peers` to a list of peer nodes (network public
 keys).
 
-# Does the PBFT implementation follow the original paper?
+## Does the PBFT implementation follow the original paper?
 
 Yes, it follows the original 1999 Castro and Liskov paper with some
 modifications and optimizations.
 
-# Does the PoET CFT implement the same consensus algorithm as PoET SGX?
+## Does the PoET CFT implement the same consensus algorithm as PoET SGX?
 
 Yes\--they are same same consensus algorithm. The difference is the PoET
 CFT also simulates the enclave module, allowing PoET to run on non-SGX
 hardware.
 
-# For PoET CFT (PoET Simulator), should I generate my own `simulator_rk_pub.pem` file or do I use the one in `/etc/sawtooth/` ?
+## For PoET CFT (PoET Simulator), should I generate my own `simulator_rk_pub.pem` file or do I use the one in `/etc/sawtooth/` ?
 
 No, you use the one that is installed. It must match the private key
 that is in the PoET Simulator. The public key is needed to verify
 attestation verification reports from PoET.
 
-# What is unpluggable consensus?
+## What is unpluggable consensus?
 
 Sawtooth supports unpluggable consensus, meaning you can change the
 consensus algorithm on the fly, at a block boundary. Changing consensus
@@ -91,12 +92,12 @@ on the fly means it is done without stopping validators, flushing state,
 or starting over with a new genesis block. It is also called Dynamic
 Consensus.
 
-# Can my Sawtooth network have validators with a mixture of PoET SGX and PoET CFT?
+## Can my Sawtooth network have validators with a mixture of PoET SGX and PoET CFT?
 
 No. You need to pick one consensus for all nodes. But you can change
 consensus after the Sawtooth network has started.
 
-# What protections does PoET CFT have, since it is not BFT?
+## What protections does PoET CFT have, since it is not BFT?
 
 It is for systems that do not have SGX and do not require BFT. Both PoET
 CFT and PoET SGX have tests to guard against bad actors, such as the \"Z
@@ -105,19 +106,19 @@ simulates the SGX environment and provides CFT. That said, PoET SGX is
 preferred because of the additional SGX protections for generating the
 wait time.
 
-# What cloud services offer SGX?
+## What cloud services offer SGX?
 
 SGX is available on IBM cloud and Alibaba. Early access was available on
 Microsoft Azure, but not now.
 
-# Does PoET SGX function with SGX on cloud services?
+## Does PoET SGX function with SGX on cloud services?
 
 No. For PoET SGX to function, one also needs Platform Services (PSW),
 which is not available from any cloud provider. Instead, one can use
 PoET CFT, which is also supported. But other software software that
 requires SGX may be deployed on cloud services.
 
-# I get this error during PoET SGX registration: \"Machine requires update (probably BIOS) for SGX compliance.\"
+## I get this error during PoET SGX registration: \"Machine requires update (probably BIOS) for SGX compliance.\"
 
 During EPID provisioning your computer is trying to get an anonymous
 credential from Intel. If that process is failing one possibility is
@@ -128,22 +129,22 @@ for that platform.
 
 SGX also needs to be enabled in the BIOS menu.
 
-# Does Sawtooth require a certain processor to be deployed on a network?
+## Does Sawtooth require a certain processor to be deployed on a network?
 
 No. If you use PoET SGX consensus you need a processor that supports
 SGX.
 
-# Does Sawtooth require SGX?
+## Does Sawtooth require SGX?
 
 No. SGX is only needed if you use the hardened version of PoET, PoET
 SGX. We also have a version of PoET that just uses conventional
 software, PoET CFT, which runs on a Sawtooth network with any processor.
 
-# How is PoET duration time computed?
+## How is PoET duration time computed?
 
 It is `duration = random_float(0,1) * local_mean_wait_time`
 
-# Why does PoET use exponentially-distributed random variable function instead of a uniform function?
+## Why does PoET use exponentially-distributed random variable function instead of a uniform function?
 
 That is to minimize the number of \"collisions\" in the distribution of
 a given round of wait timers generated by the population, where
@@ -154,11 +155,11 @@ is determined by examining the last N blocks. In an ideal world, you
 want a distribution where one and only one random wait time is around
 the desired inter block duration, and then there is a decent sized gap.
 
-# Where is PoET 1.0 Specification?
+## Where is PoET 1.0 Specification?
 
 <https://sawtooth.hyperledger.org/docs/core/releases/latest/architecture/poet.html>
 
-# Why is PoET SGX Byzantine Fault Tolerant?
+## Why is PoET SGX Byzantine Fault Tolerant?
 
 Because the PoET waiting time is enforced with an SGX enclave. There is
 also more defense-in-depth checks, but that doesn\'t make it BFT. In
@@ -167,7 +168,7 @@ hashing, which is effectively the same thing (although more wasteful)
 than PoET\'s trusted timer. For details, see the PoET 1.0 spec in the
 link above.
 
-# Where is the PoET SGX Enclave configuration file?
+## Where is the PoET SGX Enclave configuration file?
 
 It is at `/etc/sawtooth/poet_enclave_sgx.toml` . It is only for
 configuring PoET SGX Enclave, not the PoET CFT (PoET without SGX). A
@@ -176,13 +177,13 @@ sample file is at
 The configuration is documented at
 <https://sawtooth.hyperledger.org/docs/core/releases/latest/sysadmin_guide/configuring_sawtooth/poet_sgx_enclave_configuration_file.html>
 
-# I run `sudo -u sawtooth poet registration create . . .` and get `Permission denied: 'poet_genesis.batch'` error
+## I run `sudo -u sawtooth poet registration create . . .` and get `Permission denied: 'poet_genesis.batch'` error
 
 Change to a sawtooth user-writable directory before running the command
 and make sure file [poet_genesis.batch]{.title-ref} does not already
 exist: `cd /tmp; ls poet_genesis.batch`
 
-# What does `Consensus not ready to build candidate block` mean?
+## What does `Consensus not ready to build candidate block` mean?
 
 This message is usually an innocuous information message. It usually
 means that the validator isn\'t yet registered in the validator registry
@@ -205,7 +206,7 @@ initial launch. You can relax these parameters (see
 [Settings](/faq/settings/) in this FAQ) or, easier yet, relaunch the
 network.
 
-# What does `Failed to create wait certificate: Cannot create wait certificate because timer has timed out` mean?
+## What does `Failed to create wait certificate: Cannot create wait certificate because timer has timed out` mean?
 
 It means too much time has elapsed between the creation of the wait
 timer and the attempt to finalize the block and create the wait
@@ -217,7 +218,7 @@ message is kind of unusual. In versions of Sawtooth before 1.0, we
 waited until the entire schedule executed, which could be quite long
 running, and this message was quite common.
 
-# How do I change the Sawtooth consensus algorithm?
+## How do I change the Sawtooth consensus algorithm?
 
 -   Install the software package containing the consensus engine you
     wish to use on all nodes, if it is not already installed.
@@ -235,14 +236,14 @@ Here is an example that changes the consensus to Raft:
 
 :   `sawset proposal create --url http://localhost:8008 --key /etc/sawtooth/keys/validator.priv  \ sawtooth.consensus.algorithm=raft sawtooth.consensus.raft.peers=\ '["0276f8fed116837eb7646f800e2dad6d13ad707055923e49df08f47a963547b631", \ "035d8d519a200cdb8085c62d6fb9f2678cf71cbde738101d61c4c8c2e9f2919aa"]'`
 
-# How do I change the consensus algorithm for a network that has forked?
+## How do I change the consensus algorithm for a network that has forked?
 
 Bring the network down to one node with the preferred blocks and submit
 your consensus change proposal. Bring in the other nodes, with any
 consensus-required TPs running (for example, PoET requires the Validator
 Registry TP).
 
-# Where can I find information on the proposed PoET2 algorithm?
+## Where can I find information on the proposed PoET2 algorithm?
 
 PoET2 is different from PoET in that it supports SGX without relying on
 Intel Platform Services Enclave (PSE), making it suitable in cloud
@@ -255,21 +256,21 @@ presentation (2018-08-23) is at
 <https://drive.google.com/drive/folders/0B_NJV6eJXAA1VnFUakRzaG1raXc>
 (starting at 7:45)
 
-# What is the Intel Platform Developers Kit for Blockchain - Ubuntu?
+## What is the Intel Platform Developers Kit for Blockchain - Ubuntu?
 
 The PDK is a small form factor computer with SGX with Ubuntu,
 Hyperledger Sawtooth, and development software pre-installed. For
 information, see
 <https://designintools.intel.com/Intel_Platform_Developers_Kit_for_Blockchain_p/q6uidcbkcpdk.htm>
 
-# Where is the Consensus Engine API documented?
+## Where is the Consensus Engine API documented?
 
 At <https://github.com/hyperledger/sawtooth-rfcs/pull/4> See also the
 \"Sawtooth Consensus Engines\" video at
 20180426-sawtooth-tech-forum.mp4, starting at 10:00, in directory
 <https://drive.google.com/drive/folders/0B_NJV6eJXAA1VnFUakRzaG1raXc>
 
-# What are the minimum number of nodes needed for PoET?
+## What are the minimum number of nodes needed for PoET?
 
 PoET needs at least 3 nodes, but works best with at least 5 nodes. This
 is to avoid Z Test failures (a node winning too frequently). In
@@ -277,7 +278,7 @@ production, to keep a blockchain safe, more nodes are always better,
 regardless of the consensus. 10 nodes are good for internal testing. For
 production, have 2 nodes per identity.
 
-# Can PoET be configured for small networks?
+## Can PoET be configured for small networks?
 
 Yes, for development purposes. For production purposes, consider using
 another consensus algorithm. For example, Raft or PBFT handles a small
@@ -291,7 +292,7 @@ for small test networks (say, \< \~12 nodes) with:
     sawtooth.poet.key_block_claim_limit= 100000
     sawtooth.poet.ztest_minimum_win_count=999999999
 
-# How should peer nodes be distributed?
+## How should peer nodes be distributed?
 
 Blockchain achieves fault tolerance by having its state (data)
 completely duplicated among the peer nodes. Best practice means
@@ -300,20 +301,20 @@ Distributing nodes on virtual machines sharing the same host does
 nothing to guard against hardware faults. Distributing nodes at the same
 site does not protect against site outages.
 
-# Can I restrict what validator nodes win consensus?
+## Can I restrict what validator nodes win consensus?
 
 No. Every peer node validates blocks and every peer node can publish a
 block. You can write your own plugin consensus module to restrict what
 peer nodes win. Or modify an existing consensus module to experiment.
 
-# How do I restart a consensus engine?
+## How do I restart a consensus engine?
 
 First stop the validator, then restart the consensus engine. If you
 leave the validator engine running, it will not connect to the restarted
 consensus engine. See
 <https://jira.hyperledger.org/projects/STL/issues/STL-1465>
 
-# Do I start the consensus engine before or after the validator?
+## Do I start the consensus engine before or after the validator?
 
 The consensus engine can start before or after the validator. The
 preferred order is to start the validator first, then the consensus
@@ -321,7 +322,7 @@ engine. If you start the consensus engine before the validator, the
 consensus engine will retry connecting to the validator (through TCP
 port 5050) until it the consensus engine is successful.
 
-# What can cause a fork with PoET?
+## What can cause a fork with PoET?
 
 In PoET, forks occur due to a network partition, the size of the
 network, the time it takes to transfer and validate blocks across the
@@ -332,7 +333,7 @@ TPs don't really affect forks, unless they have a severe impact on the
 validation duration of the block. However, unresolvable forks due to
 non-determinism, are likely a TP problem.
 
-# How do I fix PoET using Intel SGX IAS API version 2, which is end of life?
+## How do I fix PoET using Intel SGX IAS API version 2, which is end of life?
 
 For those who are trying to use PoET SGX with IAS, you need to move to
 the IAS API v3 interface. Basically just go through and change the IAS
@@ -344,8 +345,6 @@ be made in files
 The Intel SGX IAS v3 API is at
 <https://software.intel.com/sites/default/files/managed/7e/3b/ias-api-spec.pdf>
 
-::: mininav
 [PREVIOUS](/faq/validator/) [TOP](/faq/) [NEXT](/faq/client/)
-:::
 
 © Copyright 2018, Intel Corporation.

--- a/faq/docker.md
+++ b/faq/docker.md
@@ -1,21 +1,23 @@
-\-\--layout: page hide: true tags: \[faq\] title: Sawtooth FAQ - Using
-Docker permalink: /faq/docker/ \# Copyright (c) 2018, Intel Corporation.
-\# Licensed under Creative Commons Attribution 4.0 International License
-\# <https://creativecommons.org/licenses/by/4.0/> \-\--Sawtooth FAQ:
-Using Docker ==========================
+---
+layout: default
+hide: true
+tags: [faq]
+title: Sawtooth FAQ - Using Docker
+permalink: /faq/docker/
+# Copyright (c) 2018, Intel Corporation.
+# Licensed under Creative Commons Attribution 4.0 International License
+# <https://creativecommons.org/licenses/by/4.0/>
+---
 
-::: mininav
+# Sawtooth FAQ: Using Docker
+
 [PREVIOUS](/faq/permissioning/) [TOP](/faq/) [NEXT](/faq/upgrade/)
-:::
-
-::: contents
-:::
 
 # Can I run Sawtooth without Docker?
 
 Yes.
 
-# How can I run `docker` or `docker-compose` without prefixing it with `sudo`?
+## How can I run `docker` or `docker-compose` without prefixing it with `sudo`?
 
 Sometimes, adding your login to group `docker` is recommended, such as
 with command: `sudo usermod -aG docker $USER` . However, this gives
@@ -30,7 +32,7 @@ alias docker-compose='sudo docker-compose'
 For details, see
 <https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user>
 
-# I get this error running `docker-compose -f sawtooth-default.yaml up` : `Error: files exist, rerun with --force to overwrite existing files`
+## I get this error running `docker-compose -f sawtooth-default.yaml up` : `Error: files exist, rerun with --force to overwrite existing files`
 
 This occurs when docker was not halted cleanly. Run the following first:
 
@@ -50,7 +52,7 @@ An alternate solution is to force it to ignore the existing files:
 docker-compose -f docker/compose/sawtooth-default.yaml up --force
 ```
 
-# I get this error running `docker-compose -f sawtooth-default.yaml up` : `ERROR: Couldn't connect to Docker daemon at http+docker://localhost - is it running?`
+## I get this error running `docker-compose -f sawtooth-default.yaml up` : `ERROR: Couldn't connect to Docker daemon at http+docker://localhost - is it running?`
 
 If it\'s at a non-standard location, specify the URL with the
 DOCKER_HOST environment variable.
@@ -64,7 +66,7 @@ service docker status
 sudo service docker start
 ```
 
-# I get this error running `docker run hello-world` : `Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Get http://%2Fvar%2Frun%2Fdocker.sock/v1.37/containers/json: dial unix /var/run/docker.sock: connect: permission denied`
+## I get this error running `docker run hello-world` : `Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Get http://%2Fvar%2Frun%2Fdocker.sock/v1.37/containers/json: dial unix /var/run/docker.sock: connect: permission denied`
 
 Try running with sudo. For example: sudo docker run hello-world. Here\'s
 a few aliases you can add to your `~/.bashrc` file:
@@ -74,7 +76,7 @@ alias docker='sudo docker'
 alias docker-compose='sudo docker-compose'
 ```
 
-# I get this error running `docker run hello-world` : `docker: Error response from daemon: Get https://registry-1.docker.io/v2/: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers).`
+## I get this error running `docker run hello-world` : `docker: Error response from daemon: Get https://registry-1.docker.io/v2/: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers).`
 
 If it worked before, first try restarting docker:
 
@@ -91,15 +93,15 @@ pattern:
     export https_proxy="https://proxy.mycompany.com:912/"
     export no_proxy=".mycompany.com,10.0.0.0/8,192.168.0.0/16,localhost,127.0.0.0/8"
 
-# I get this error: `ERROR: repository . . . not found: does not exist or no pull access`
+## I get this error: `ERROR: repository . . . not found: does not exist or no pull access`
 
 Also a proxy problem\--see the answer above.
 
-# I get this error: `ERROR: Service . . . failed to build: Get . . . net/http: request canceled while waiting for connection`
+## I get this error: `ERROR: Service . . . failed to build: Get . . . net/http: request canceled while waiting for connection`
 
 Also a proxy problem\--see the answer above.
 
-# I get this error running docker-compose: `ERROR: for validator  Cannot create container for service validator: Conflict. The container name "/validator" is already in use by container ...`
+## I get this error running docker-compose: `ERROR: for validator  Cannot create container for service validator: Conflict. The container name "/validator" is already in use by container ...`
 
 The container already exists. You need to remove or rename it. To
 remove:
@@ -110,14 +112,14 @@ sudo docker stop <container ID>
 sudo docker rm <container ID>
 ```
 
-# How do I display the logs for a Docker container?
+## How do I display the logs for a Docker container?
 
 Use the `sudo docker logs` command followed by the container name. The
 container name may be found with the `sudo docker ps` command. For
 example: `sudo docker logs validator` display the log for the container
 named `validator` .
 
-# I get this error running docker-compose: `ERROR: Version in "./docker-compose.yaml" is unsupported.`
+## I get this error running docker-compose: `ERROR: Version in "./docker-compose.yaml" is unsupported.`
 
 You may be running an old version of Docker, perhaps from your Linux
 package manager. Instead, install Docker from docker.com. Sawtooth
@@ -126,7 +128,7 @@ use <https://docs.docker.com/install/linux/docker-ce/ubuntu/> Here\'s a
 sample script that installs Docker CE on Ubuntu:
 <https://gist.github.com/askmish/76e348e34d93fc22926d7d9379a0fd08>
 
-# If I run `docker` or `docker-compose` it hangs and does nothing.
+## If I run `docker` or `docker-compose` it hangs and does nothing.
 
 The docker daemons may not be running. To check, run:
 
@@ -140,7 +142,7 @@ To start, run:
 $ sudo systemctl restart docker.service
 ```
 
-# How do I manually start and stop docker on Linux?
+## How do I manually start and stop docker on Linux?
 
 ``` sh
 $ sudo service docker start
@@ -148,7 +150,7 @@ $ service docker status
 $ sudo service docker stop
 ```
 
-# How do I enable and disable automatic start of docker on boot on Linux?
+## How do I enable and disable automatic start of docker on boot on Linux?
 
 ``` sh
 $ sudo systemctl enable docker
@@ -156,7 +158,7 @@ $ systemctl status docker
 $ sudo systemctl disable docker
 ```
 
-# Can I connect a client to the REST API running in a Docker container?
+## Can I connect a client to the REST API running in a Docker container?
 
 Yes. The `docker-compose.yaml` needs the following lines for the REST
 container:
@@ -171,7 +173,7 @@ This might be a command line option for the client (for example,
 `intkey --url http://localhost:4040`). Otherwise, you need to modify the
 source if the REST API URL is hard-coded for your client.
 
-# Can I connect a transaction processor to the validator running in a Docker container?
+## Can I connect a transaction processor to the validator running in a Docker container?
 
 Yes. The `docker-compose.yaml` needs the following lines for the
 validator container (which maps Docker container TCP port 4004 to
@@ -189,12 +191,12 @@ TP. (for example, `intkey-tp-python -v tcp://localhost:4040` ).
 Otherwise, you need to modify the source if the validator port is
 hard-coded for your TP.
 
-# I get `You cannot remove a running container` error removing docker containers
+## I get `You cannot remove a running container` error removing docker containers
 
 Before running `docker rm $(docker ps -aq)`, first stop the running
 containers with `sudo docker stop $(docker ps -q)`
 
-# How do I run Sawtooth with Kubernetes?
+## How do I run Sawtooth with Kubernetes?
 
 Kubernetes requires VirtualBox or some other virtual machine software.
 Documentation on using Kubernetes with Minikube for Sawtooth on Linux or
@@ -202,12 +204,12 @@ Mac hosts is available here:
 <https://sawtooth.hyperledger.org/docs/core/nightly/master/app_developers_guide/kubernetes.html>
 <https://sawtooth.hyperledger.org/docs/core/nightly/master/app_developers_guide/creating_sawtooth_network.html#kubernetes-start-a-multiple-node-sawtooth-network>
 
-# Can Docker run inside a virtual machine?
+## Can Docker run inside a virtual machine?
 
 Yes. For example, I run Docker with Sawtooth containers on a VirtualBox
 virtual machine instance on a Windows 10 host.
 
-# How do I persist data on Docker containers?
+## How do I persist data on Docker containers?
 
 You add an external volume. You make a directory for your volume and add
 it using `volumes:` in your Docker .yaml file. For a Sawtooth-specific
@@ -224,14 +226,14 @@ For a list of directories used by Sawtooth, see
 It is best to set [\$SAWTOOTH_HOME]{.title-ref} so all the configuration
 and data is under one root directory.
 
-# I get this error running Docker: `ERROR: manifest for hyperledger/sawtooth-validator:1.2 not found`
+## I get this error running Docker: `ERROR: manifest for hyperledger/sawtooth-validator:1.2 not found`
 
 You are following instructions for the unreleased Sawtooth `nightly`
 build. There are no Docker images for the nightly build. Instead use the
 `latest` build documentation at
 <https://sawtooth.hyperledger.org/docs/core/releases/latest/app_developers_guide.html>
 
-# Why doesn\'t sawtooth-default-poet.yaml start the network successfully on subsequent runs ?
+## Why doesn\'t sawtooth-default-poet.yaml start the network successfully on subsequent runs ?
 
 The root cause is the stale volume mounted, these are mounted for
 storing sawtooth keys in order to share between the containers. If you
@@ -243,8 +245,6 @@ containers and volumes
 
     docker-compose down -v
 
-::: mininav
 [PREVIOUS](/faq/permissioning/) [TOP](/faq/) [NEXT](/faq/upgrade/)
-:::
 
 © Copyright 2018, Intel Corporation.

--- a/faq/faq.md
+++ b/faq/faq.md
@@ -1,14 +1,22 @@
-\-\--layout: page title: FAQ permalink: /faq/ order: 4 feature-img:
-\"examples/img/hero-bg.jpg\" feat_img_size: small \# Copyright (c) 2018,
-Intel Corporation. \# Licensed under Creative Commons Attribution 4.0
-International License \# <https://creativecommons.org/licenses/by/4.0/>
-\-\--Hyperledger Sawtooth FAQ ========================
+---
+layout: default
+Title: FAQ
+permalink: /faq/
+order: 4
+feature-img: "examples/img/hero-bg.jpg"
+feat_img_size: small
+# Copyright (c) 2018, Intel Corporation.
+# Licensed under Creative Commons Attribution 4.0 International License
+# <https://creativecommons.org/licenses/by/4.0/>
+---
+
+# Hyperledger Sawtooth FAQ
 
 Answers to frequently asked questions for Hyperledger Sawtooth. Many
 questions and answers originated from the #sawtooth Rocket.Chat channel
 at <https://chat.hyperledger.org/channel/sawtooth>
 
-# Sawtooth FAQ Sections
+## Sawtooth FAQ Sections
 
 -   [Hyperledger Sawtooth in General](sawtooth)
 -   [Installation and Configuration](installation)
@@ -21,14 +29,14 @@ at <https://chat.hyperledger.org/channel/sawtooth>
 -   [Using Docker](docker)
 -   [Upgrading Hyperledger Sawtooth](upgrade)
 
-# FAQ Appendixes
+## FAQ Appendixes
 
 -   [Sawtooth Glossary](glossary)
 -   [Transaction Family Prefixes](prefixes)
 -   [Configuration Settings](settings)
 -   [Sawtooth Videos](videos)
 
-# Contributing to This FAQ
+## Contributing to This FAQ
 
 This FAQ is licensed under Creative Commons Attribution 4.0
 International License. You may obtain a copy of the license at:
@@ -41,8 +49,6 @@ Each commit must include a `Signed-off-by:` in the commit message
 the [Developer Certificate of Origin
 (DCO)](https://developercertificate.org/).\]
 
-::: mininav
 [NEXT](/faq/sawtooth/)
-:::
 
 © Copyright 2018, Intel Corporation.

--- a/faq/glossary.md
+++ b/faq/glossary.md
@@ -1,17 +1,19 @@
-\-\--layout: page hide: true tags: \[appendix\] title: Appendix -
-Glossary permalink: /faq/glossary/ \# Copyright (c) 2018, Intel
-Corporation. \# Licensed under Creative Commons Attribution 4.0
-International License \# <https://creativecommons.org/licenses/by/4.0/>
-\-\--FAQ Appendix: Sawtooth Glossary ===============================
+---
+layout: default
+hide: true
+tags: [appendix]
+title: Appendix - Glossary
+permalink: /faq/glossary/
+# Copyright (c) 2018, Intel Corporation.
+# Licensed under Creative Commons Attribution 4.0 International License
+# <https://creativecommons.org/licenses/by/4.0/>
+---
 
-::: mininav
+# FAQ Appendix: Sawtooth Glossary
+
 [PREVIOUS](/faq/upgrade/) [FAQ](/faq/) [NEXT](/faq/prefixes/)
-:::
 
-::: contents
-:::
-
-# See Also
+## See Also
 
 Sawtooth Glossary
 
@@ -25,7 +27,7 @@ PoET Definitions
 
 :   <https://sawtooth.hyperledger.org/docs/core/releases/latest/architecture/poet.html#definitions>
 
-# Glossary
+## Glossary
 
 Address (aka State Address)
 
@@ -615,8 +617,6 @@ zkSNARKS
 :   Zero Knowledge Succinct Non-interactive Arguments of Knowledge,
     which allow proof of correctness, given public and private input
 
-::: mininav
 [PREVIOUS](/faq/upgrade/) [FAQ](/faq/) [NEXT](/faq/prefixes/)
-:::
 
 © Copyright 2018, Intel Corporation.

--- a/faq/installation.md
+++ b/faq/installation.md
@@ -1,18 +1,20 @@
-\-\--layout: page hide: true tags: \[faq\] title: Sawtooth FAQ -
-Installation and Configuration permalink: /faq/installation/ \#
-Copyright (c) 2018, Intel Corporation. \# Licensed under Creative
-Commons Attribution 4.0 International License \#
-<https://creativecommons.org/licenses/by/4.0/> \-\--Sawtooth FAQ:
-Installation and Configuration
-============================================ .. class:: mininav
+---
+layout: default
+hide: true
+tags: [faq]
+title: Sawtooth FAQ - Installation and Configuration
+permalink: /faq/installation/
+# Copyright (c) 2018, Intel Corporation.
+# Licensed under Creative Commons Attribution 4.0 International License
+# <https://creativecommons.org/licenses/by/4.0/>
+---
+
+# Sawtooth FAQ: Installation and Configuration
 
 [PREVIOUS](/faq/sawtooth/) [TOP](/faq/)
 [NEXT](/faq/transaction-processing/)
 
-::: contents
-:::
-
-# How do I list and install Sawtooth packages?
+## How do I list and install Sawtooth packages?
 
 The following setups the Sawtooth stable repository, lists the packages,
 and installs the core packages (sawtooth, python3-sawtooth-cli,
@@ -29,7 +31,7 @@ $ apt search sawtooth
 For more, up-to-date installation information see
 <https://sawtooth.hyperledger.org/docs/core/releases/latest/sysadmin_guide/installation.html>
 
-# How do I edit Sawtooth settings?
+## How do I edit Sawtooth settings?
 
 With `.toml` configuration files in `/etc/sawtooth` . Examples are in
 the directory as `.toml.example` . For details, see
@@ -71,14 +73,14 @@ Configuration files include:
 
 More transaction-processor specific configuration files may be present.
 
-# I get this error installing Ubuntu packages: `Could not get lock /var/lib/dpkg/lock`
+## I get this error installing Ubuntu packages: `Could not get lock /var/lib/dpkg/lock`
 
 The file lock is probably left over from a previous failed install. The
 solution is `sudo rm  /var/lib/dpkg/lock` . This assumes you\'re not
 multitasking and installing something else in another terminal on the
 same host.
 
-# I get this error installing `sawtooth-cxx-sdk`: `Depends: protobuf but it is not installable`
+## I get this error installing `sawtooth-cxx-sdk`: `Depends: protobuf but it is not installable`
 
 The C++ SDK package is in the nightly repository. Until the package
 dependency is fixed, here\'s a workaround to force an install:
@@ -92,28 +94,28 @@ $ sudo dpkg -i  sawtooth-cxx-sdk_1.1.1.dev808_amd64.deb
 $ pkg contents sawtooth-cxx-sdk
 ```
 
-# I get this error when running `sawtooth setting list` or `xo list` : `Error 503: Service Unavailable`
+## I get this error when running `sawtooth setting list` or `xo list` : `Error 503: Service Unavailable`
 
 This usually occurs when there is no genesis node created. To create,
 type the following:
 
 ``` sh
-# Create the genesis node:
+## Create the genesis node:
 sawtooth keygen
 sawset genesis
 sudo -u sawtooth sawadm genesis config-genesis.batch
-# Start the validator:
+## Start the validator:
 sudo sawadm keygen
 sudo -u sawtooth sawtooth-validator -vv
 ```
 
-# I get this error when running `sudo -u sawtooth sawadm genesis config-genesis.batch` : `Permission denied`
+## I get this error when running `sudo -u sawtooth sawadm genesis config-genesis.batch` : `Permission denied`
 
 Change to a sawtooth user-writable directory before running the command
 and make sure file [config-genesis.batch]{.title-ref} does not already
 exist: `cd /tmp; ls config-genesis.batch`
 
-# I get a `Key file is not readable` error when starting `sudo -u sawtooth sawtooth-validator -vv`
+## I get a `Key file is not readable` error when starting `sudo -u sawtooth sawtooth-validator -vv`
 
 The validator key file permissions are wrong. To fix it, type:
 
@@ -131,29 +133,29 @@ drwxr-xr-x 2 root sawtooth 4096 Jan 11 11:35 .
 
 If the validator key files are missing, type `sudo sawadm keygen`
 
-# How to I delete all blockchain data?
+## How to I delete all blockchain data?
 
 Type the following: `sudo -u sawtooth rm -rf /var/lib/sawtooth/*` This
 deletes the entire database\--for development and purposes.
 
-# How do I delete or change a specific block in the blockchain?
+## How do I delete or change a specific block in the blockchain?
 
 You cannot delete blocks\--they are immutable by design. You can create
 a new transaction (or block of transactions) that reverse a previous
 transaction.
 
-# I get a usage error running `sawnet peers` or `sawnet list-blocks`
+## I get a usage error running `sawnet peers` or `sawnet list-blocks`
 
 You should upgrade to the current release. These commands were added
 after the Sawtooth 1.0.4 release and are not available in earlier
 releases.
 
-# How can I change on-chain settings without deleting the blockchain?
+## How can I change on-chain settings without deleting the blockchain?
 
 Use the `sawset` command. This allows you to change settings such as
 maximum batches per block or target wait time.
 
-# I got error `gpg: keyserver receive failed: keyserver error` when executing `sudo apt-key adv --keyserver hkp://keyserver...`
+## I got error `gpg: keyserver receive failed: keyserver error` when executing `sudo apt-key adv --keyserver hkp://keyserver...`
 
 This error means your machine couldn\'t add the supplied key to trusted
 list. This key is later used to authenticate and get sawtooth package.
@@ -163,7 +165,7 @@ in the command to solve this issue. For example,
 `sudo apt-key adv --keyserver-options http-proxy=http://[username:password]@<proxyserver>:<port> --keyserver hkp://keyse...`
 (notice usage of flag `--keyserver-options` here).
 
-# What does this error mean `repository ... xenial InRelease' doesn't support architecture 'i386'`?
+## What does this error mean `repository ... xenial InRelease' doesn't support architecture 'i386'`?
 
 Following could be possibilities:
 
@@ -175,19 +177,19 @@ Following could be possibilities:
     example,
     `sudo add-apt-repository 'deb [arch=amd64] http://repo.sawtooth.me/ubuntu.....'`.
 
-# I get this error running `sawset`: `ModuleNotFoundError: No module named 'colorlog'`
+## I get this error running `sawset`: `ModuleNotFoundError: No module named 'colorlog'`
 
 Something went wrong with installing Python dependencies or they were
 removed. In this case, install `colorlog` with
 `sudo apt install python3-colorlog` or with`pip3 install colorlog`
 
-# I get this error starting Sawtooth: `lmdb.DiskError: /var/lib/sawtooth/poet-key-state-03efb2aa.lmdb: No space left on device`
+## I get this error starting Sawtooth: `lmdb.DiskError: /var/lib/sawtooth/poet-key-state-03efb2aa.lmdb: No space left on device`
 
 Besides the obvious problem of no disk space, it could be your OS or
 filesystem does not support sparse files. The LMDB databases used by
 Sawtooth are 1TB sparse (mostly unallocated) files.
 
-# I get this error when running `sawtooth sawadm genesis config-genesis.batch`: `Processing config-genesis.batch... Error: Unable to read config-genesis.batch`
+## I get this error when running `sawtooth sawadm genesis config-genesis.batch`: `Processing config-genesis.batch... Error: Unable to read config-genesis.batch`
 
 This error can occur when there is no sawtooth user and group. This
 should have been done by the package `postinst` script. To add, type
@@ -202,7 +204,7 @@ move it to a sawtooth-writable directory. For example
 Another cause is the file doesn\'t exist. Create it with
 `sawset genesis` .
 
-# How do I install Sawtooth on Ubuntu?
+## How do I install Sawtooth on Ubuntu?
 
 Follow the instructions at
 <https://sawtooth.hyperledger.org/docs/core/releases/latest/app_developers_guide/ubuntu.html>
@@ -229,7 +231,7 @@ $ sudo -u sawtooth devmode-engine-rust -vv --connect tcp://localhost:5050
     the consensus engine connected with validator TCP port 5050 (for
     consensus messages).
 
-# How do I install Sawtooth on AWS?
+## How do I install Sawtooth on AWS?
 
 -   Sign up for a free AWS Free Tier account, if you don\'t have an
     account. The AWS Free Tier is free for qualifying developers. This
@@ -243,7 +245,7 @@ $ sudo -u sawtooth devmode-engine-rust -vv --connect tcp://localhost:5050
 -   Then follow the instructions for using your Sawtooth AWS instance at
     <https://sawtooth.hyperledger.org/docs/core/nightly/master/app_developers_guide/aws.html>
 
-# How do I use ssh with AWS?
+## How do I use ssh with AWS?
 
 By default ssh access to AWS instances are disabled. To enable, first
 paste the contents of your public key, at `~/.ssh/id_rsa.pub` , to
@@ -257,7 +259,7 @@ Select the `Inbound` tab and `Edit`. Add `SSH` (TCP port 22) and Source
 the instance (Actions \--\> InstanceState \--\> Reboot) to get it to
 work.
 
-# How to I build Sawtooth from source?
+## How to I build Sawtooth from source?
 
 Use `git` to download the source, then `build_all` to build. Type
 `./bin/build_all` for options. For example: .. code:: sh
@@ -269,7 +271,7 @@ Use `git` to download the source, then `build_all` to build. Type
 For details, see
 <https://github.com/hyperledger/sawtooth-core/blob/master/BUILD.md>
 
-# How do I install Sawtooth on FreeBSD?
+## How do I install Sawtooth on FreeBSD?
 
 Sawtooth is supported for Ubuntu Linux with binary packages. For other
 other \*IX-like systems, including FreeBSD, you can build from source.
@@ -279,7 +281,7 @@ The following blog may help:
 status of the FreeBSD Sawtooth port:
 <https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=228581>
 
-# I get this error while installing Sawtooth: `Error starting userland proxy: listen tcp 0.0.0.0:8080: bind: address already in use`
+## I get this error while installing Sawtooth: `Error starting userland proxy: listen tcp 0.0.0.0:8080: bind: address already in use`
 
 You already have a program running that uses TCP port 8080. Either kill
 it or change the port you use to something else. To find the process(es)
@@ -287,7 +289,7 @@ that have port 8080 open, type `sudo lsof -t -i:8080` Then kill the
 processes. Check again that they have not restarted. Also check that
 they are not Docker containers that have restarted.
 
-# I get this error after setting up a Sawtooth network: `Can't send message PING_RESPONSE back to ... because connection OutboundConnectionThread- tcp://192.168.0.100:8800 not in dispatcher`
+## I get this error after setting up a Sawtooth network: `Can't send message PING_RESPONSE back to ... because connection OutboundConnectionThread- tcp://192.168.0.100:8800 not in dispatcher`
 
 The usual problem when you get this message is configuring the peer
 endpoints
@@ -315,7 +317,7 @@ endpoints
     instead of 127.0.0.1 (localhost only). Be careful doing this as may
     open up this port to external networks.
 
-# I get `unmet dependencies` errors installing Sawtooth on Ubuntu 18.04 LTS.
+## I get `unmet dependencies` errors installing Sawtooth on Ubuntu 18.04 LTS.
 
 Ubuntu 18.04 LTS is supported only in the nightly development packages.
 Use Ubuntu 16.04 LTS for the stable release packages. You can also
@@ -330,13 +332,13 @@ install instead of parent package `sawtooth`. For example,
 For details, see
 <https://jira.hyperledger.org/projects/STL/issues/STL-1465>
 
-# I get this error installing Sawtooth: `No matching distribution found for sawtooth_rest_api`
+## I get this error installing Sawtooth: `No matching distribution found for sawtooth_rest_api`
 
 You tried to install Sawtooth using Python pip. I don\'t know if this
 could work. I know installing Sawtooth using Ubuntu/Debian installation
 tools (such as apt, apt-get, dpkg, aptitude) works OK.
 
-# I get this error with `add-apt-repository`: Couldn\'t connect to accessibility bus: Failed to connect to socket . . . Connection refused
+## I get this error with `add-apt-repository`: Couldn\'t connect to accessibility bus: Failed to connect to socket . . . Connection refused
 
 It is just a warning and you can ignore it. Verify the Sawtooth
 repository was added in `/etc/apt/sources.list` The cause is the command
@@ -344,19 +346,19 @@ tried to start a graphic display (probably over SSH) when it was not
 available. A workaround to remove the warning is to add
 `export NO_AT_BRIDGE=1` to `~/.bashrc`
 
-# I get this error starting Sawtooth on Docker: `No response from ... beginning heartbeat pings`
+## I get this error starting Sawtooth on Docker: `No response from ... beginning heartbeat pings`
 
 This means there is a problem with the genesis node and peer nodes
 connecting.
 
-# How do I list sawtooth command line options?
+## How do I list sawtooth command line options?
 
 For the Sawtooth CLIs (sawadm, sawset, sawnet, sawtooth), append `-h`
 after the command to list subcommands (for example, `sawadm -h` ). For
 the Sawtooth subcommands, append `-h` after the subcommand (for example,
 `sawadm keygen -h` ).
 
-# Why do I get a `No module named ...` error running a Sawtooth program?
+## Why do I get a `No module named ...` error running a Sawtooth program?
 
 The `No module named` error occurs in Python when a Python module is
 missing. The usual fix is to install the corresponding Python package.
@@ -364,13 +366,13 @@ Something you need to prepend `python3-` to the name. So, for example,
 if you get a `No module named 'netifaces'` error, install the missing
 package with something like `apt install python3-netifaces`
 
-# How do I fix this error: `no transaction processors registered for processor type sawtooth_settings` ??
+## How do I fix this error: `no transaction processors registered for processor type sawtooth_settings` ??
 
 You start the Settings TP, as follows `sudo -u sawtooth settings-tp -v`
 . The Settings TP is always required for all Sawtooth nodes, even if you
 did not add or change any settings.
 
-# I get `unmet dependencies` errors on `python3-sawtooth-poet-cli` and other packages with `sudo apt-get install -y sawtooth` on Ubuntu Xenial
+## I get `unmet dependencies` errors on `python3-sawtooth-poet-cli` and other packages with `sudo apt-get install -y sawtooth` on Ubuntu Xenial
 
 The Sawtooth PoET packages are not yet available for the unreleased
 Sawtooth nightly builds on Ubuntu 18.x LTS (Xenial). As a workaround do
@@ -385,7 +387,7 @@ $ sudo apt-get install python3-sawtooth-cli python3-sawtooth-integration \
     python3-sawtooth-validator sawtooth-devmode-engine-rust
 ```
 
-# I get `Unable to start validator; sawtooth.consensus.algorithm.name and sawtooth.consensus.algorithm.version must be set in the genesis block` when installing Sawtooth 1.2 nightly builds
+## I get `Unable to start validator; sawtooth.consensus.algorithm.name and sawtooth.consensus.algorithm.version must be set in the genesis block` when installing Sawtooth 1.2 nightly builds
 
 The installation instructions for \"Step 3\" at
 <https://sawtooth.hyperledger.org/docs/core/nightly/master/app_developers_guide/ubuntu.html>
@@ -403,9 +405,7 @@ $ sudo -u sawtooth sawset proposal create \
 $ sudo -u sawtooth sawadm genesis config-genesis.batch config.batch 
 ```
 
-::: mininav
 [PREVIOUS](/faq/sawtooth/) [TOP](/faq/)
 [NEXT](/faq/transaction-processing/)
-:::
 
 © Copyright 2018, Intel Corporation.

--- a/faq/permissioning.md
+++ b/faq/permissioning.md
@@ -1,17 +1,19 @@
-\-\--layout: page hide: true tags: \[faq\] title: Sawtooth FAQ -
-Permissioning permalink: /faq/permissioning/ \# Copyright (c) 2018,
-Intel Corporation. \# Licensed under Creative Commons Attribution 4.0
-International License \# <https://creativecommons.org/licenses/by/4.0/>
-\-\--Sawtooth FAQ: Permissioning ===========================
+---
+layout: default
+hide: true
+tags: [faq]
+title: Sawtooth FAQ - Permissioning
+permalink: /faq/permissioning/
+# Copyright (c) 2018, Intel Corporation.
+# Licensed under Creative Commons Attribution 4.0 International License
+# <https://creativecommons.org/licenses/by/4.0/>
+---
 
-::: mininav
+# Sawtooth FAQ: Permissioning
+
 [PREVIOUS](/faq/rest/) [TOP](/faq/) [NEXT](/faq/docker/)
-:::
 
-::: contents
-:::
-
-# How to solve this error `Wait timed out! Policy was not committed... PENDING` when `sawtooth identity policy create` is run?
+## How to solve this error `Wait timed out! Policy was not committed... PENDING` when `sawtooth identity policy create` is run?
 
 There is a possibility that rest-api is down or identity-tp is not
 running or it might be due to permissioning issues. If the cause is due
@@ -25,8 +27,6 @@ Refer
 <https://sawtooth.hyperledger.org/docs/core/nightly/master/sysadmin_guide/configuring_permissions.html>
 for detailed information.
 
-::: mininav
 [PREVIOUS](/faq/rest/) [TOP](/faq/) [NEXT](/faq/docker/)
-:::
 
 © Copyright 2018, Intel Corporation.

--- a/faq/prefixes.md
+++ b/faq/prefixes.md
@@ -1,15 +1,17 @@
-\-\--layout: page hide: true tags: \[appendix\] title: Appendix -
-Sawtooth Transaction Family Prefixes permalink: /faq/prefixes/ \#
-Copyright (c) 2018, Intel Corporation. \# Licensed under Creative
-Commons Attribution 4.0 International License \#
-<https://creativecommons.org/licenses/by/4.0/> \-\--FAQ Appendix:
-Transaction Family Prefixes ========================================= ..
-class:: mininav
+---
+layout: default
+hide: true
+tags: [appendix]
+title: Appendix - Sawtooth Transaction Family Prefixes
+permalink: /faq/prefixes/
+# Copyright (c) 2018, Intel Corporation.
+# Licensed under Creative Commons Attribution 4.0 International License
+# <https://creativecommons.org/licenses/by/4.0/>
+---
+
+# FAQ Appendix: Transaction Family Prefixes
 
 [PREVIOUS](/faq/glossary/) [FAQ](/faq/) [NEXT](/faq/settings/)
-
-::: contents
-:::
 
 This is an unofficial list of some Transaction Family (TF) prefixes.
 There is no central registry, most or all of these TFs are found on
@@ -31,121 +33,39 @@ headers are serialized with Protobuf.
 For base TF specifications, see
 <https://sawtooth.hyperledger.org/docs/core/releases/latest/transaction_family_specifications/>
 
-+-------------+---------+-------+-------------------------------------+
-| TRANSACTION | SERIAL- | P     | PREFIX ENCODING                     |
-| FAMILY NAME | IZATION | REFIX |                                     |
-+=============+=========+=======+=====================================+
-| settings    | P       | 0     | Validator settings. Only required   |
-|             | rotobuf | 00000 | TF                                  |
-+-------------+---------+-------+-------------------------------------+
-| identity    | P       | 0     | Validator Identity for TP/Validator |
-|             | rotobuf | 0001d | keys                                |
-+-------------+---------+-------+-------------------------------------+
-| sawtooth    | P       | 6     | PoET Validator Registry. Used by    |
-| \_validator | rotobuf | a4372 | PoET consensus to track other       |
-| \_registry  |         |       | validators. See note above about    |
-|             |         |       | hash prefix .                       |
-+-------------+---------+-------+-------------------------------------+
-| blockinfo   | P       | 0     | Validator Block Info. Used for SETH |
-|             | rotobuf | 0b10c |                                     |
-|             |         |       | 00b10c00 metadata namespace info    |
-|             |         |       | about other namespaces              |
-|             |         |       |                                     |
-|             |         |       | 00b10c01 block info namespace       |
-|             |         |       | historic block info                 |
-|             |         |       |                                     |
-|             |         |       | 00b10c0100\....00\<block \# in hex> |
-|             |         |       | info on block at block \#           |
-+-------------+---------+-------+-------------------------------------+
-| sabre       | P       | 0     | WebAssembly VM: NamespaceRegistry   |
-|             | rotobuf | 0ec00 |                                     |
-|             |         |       | Wasm: ContractRegistry              |
-|             |         | 0     |                                     |
-|             |         | 0ec01 | Wasm: Contracts                     |
-|             |         |       |                                     |
-|             |         | 0     |                                     |
-|             |         | 0ec02 |                                     |
-+-------------+---------+-------+-------------------------------------+
-| seth        | P       | a     | SETH (Sawtooth Ethereum VM)         |
-|             | rotobuf | 68b06 |                                     |
-+-------------+---------+-------+-------------------------------------+
-| pdo\_       | P       | a     | Private Data Objects (PDO) Contract |
-| contract\_  | rotobuf | a2a93 | Instance Registry                   |
-| instance\_  |         |       |                                     |
-| registry    |         |       |                                     |
-+-------------+---------+-------+-------------------------------------+
-| pdo\_       | P       | 0     | Private Data Objects (PDO) Contract |
-| contract\_  | rotobuf | b936f | Enclave Registry                    |
-| enclave\_   |         |       |                                     |
-| registry    |         |       |                                     |
-+-------------+---------+-------+-------------------------------------+
-| ccl\_       | P       | d     | Private Data Objects (PDO)          |
-| contract\_  | rotobuf | b13a2 | Coordination and Commit Log (CCL)   |
-| contract\_  |         |       | Contract State Registry             |
-| state\_     |         |       |                                     |
-| registry    |         |       |                                     |
-+-------------+---------+-------+-------------------------------------+
-| > \*\*SOME  | TFs\*\* |       |                                     |
-| > EXAMPLE   |         |       |                                     |
-+-------------+---------+-------+-------------------------------------+
-| battleship  | JSON    | 6     | Battleship example game             |
-|             |         | e10df |                                     |
-+-------------+---------+-------+-------------------------------------+
-| intkey      | CBOR    | 1     | Integer Key. Full production        |
-|             |         | cf126 | example                             |
-+-------------+---------+-------+-------------------------------------+
-| smallbank   | P       | 3     | Small Bank example app              |
-|             | rotobuf | 32514 |                                     |
-+-------------+---------+-------+-------------------------------------+
-| xo          | C       | 5     | Tic-tac-toe example game            |
-|             | SV-UTF8 | b7349 |                                     |
-+-------------+---------+-------+-------------------------------------+
-| s           | P       | 3     | Asset (Fish) Supply Chain example   |
-| upply_chain | rotobuf | 400de | app                                 |
-+-------------+---------+-------+-------------------------------------+
-| marketplace | P       | c     | Marketplace example app             |
-|             | rotobuf | d6744 |                                     |
-+-------------+---------+-------+-------------------------------------+
-| transfer-   | JS      | 1     | Simple Tuna Supply Chain app. Used  |
-| chain       | ON-UTF8 | 9d832 | for edX LFS171x class               |
-+-------------+---------+-------+-------------------------------------+
-| s           | C       | 7     | Simple Wallet minimal example       |
-| implewallet | SV-UTF8 | e2664 |                                     |
-+-------------+---------+-------+-------------------------------------+
-| cookiejar   | C       | a     | Cookie Jar minimal example          |
-|             | SV-UTF8 | 4d219 |                                     |
-+-------------+---------+-------+-------------------------------------+
-| simple\_    | P       | 5     | Simple Supply example used for      |
-| supply      | rotobuf | d6af4 | future edX LFS201 class             |
-+-------------+---------+-------+-------------------------------------+
-| pirate-talk | UTF8    | a     | Pirate Talk minimal example         |
-|             |         | aaaaa |                                     |
-+-------------+---------+-------+-------------------------------------+
-| c           | raw     | 1     | Cookie Maker minimal example        |
-| ookie-maker |         | a5312 |                                     |
-+-------------+---------+-------+-------------------------------------+
-| > \*\*SOME  | ARTY    | ION   |                                     |
-| > THIRD-P   | PRODUCT | TF    |                                     |
-|             |         | s\*\* |                                     |
-+-------------+---------+-------+-------------------------------------+
-| rbac        | P       | 8     | T-Mobile NEXT Identity Platform     |
-|             | rotobuf | 563d0 |                                     |
-+-------------+---------+-------+-------------------------------------+
-| s           | P       | d     | Primechain Blockchain-eKYC bank     |
-| awtoothekyc | rotobuf | bf420 | records                             |
-+-------------+---------+-------+-------------------------------------+
-| pub_key     | P       | a     | REMME REMChain                      |
-|             | rotobuf | 23be1 |                                     |
-+-------------+---------+-------+-------------------------------------+
-| bitagora-   | JSON    | b     | Bitagora voting ballot              |
-| ballots     |         | 42861 |                                     |
-+-------------+---------+-------+-------------------------------------+
-| bitagora-   | JSON    | 1     | Bitagora voting polls               |
-| polls       |         | 54f9c |                                     |
-+-------------+---------+-------+-------------------------------------+
+[//]: # (TODO: Apply styling to table)
 
-::: mininav
+|          TRANSACTION FAMILY NAME         | SERIAL- IZATION |           PREFIX          |                                                                                                 PREFIX ENCODING                                                                                                 |
+|:----------------------------------------:|:---------------:|:-------------------------:|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
+| settings                                 | Protobuf        | 000000                    | Validator settings.  Only required TF                                                                                                                                                                           |
+| identity                                 | Protobuf        | 00001d                    | Validator Identity for TP/Validator keys                                                                                                                                                                        |
+| sawtooth _validator _registry            | Protobuf        | 6a4372                    | PoET Validator Registry. Used by PoET consensus to track other validators. See note above about hash prefix .                                                                                                   |
+| blockinfo                                | Protobuf        | 00b10c                    | Validator Block Info.  Used for SETH   00b10c00 metadata namespace info about other namespaces   00b10c01 block info namespace historic block info   00b10c0100....00<block # in hex> info on block at block #  |
+| sabre                                    | Protobuf        | 00ec00   00ec01   00ec02  | WebAssembly VM: NamespaceRegistry   Wasm: ContractRegistry   Wasm: Contracts                                                                                                                                    |
+| seth                                     | Protobuf        | a68b06                    | SETH (Sawtooth Ethereum VM)                                                                                                                                                                                     |
+| pdo_ contract_ instance_ registry        | Protobuf        | aa2a93                    | Private Data Objects (PDO) Contract Instance Registry                                                                                                                                                           |
+| pdo_ contract_ enclave_ registry         | Protobuf        | 0b936f                    | Private Data Objects (PDO) Contract Enclave Registry                                                                                                                                                            |
+| ccl_ contract_ contract_ state_ registry | Protobuf        | db13a2                    | Private Data Objects (PDO) Coordination and Commit Log (CCL) Contract State Registry                                                                                                                            |
+| SOME EXAMPLE TFs                         |                 |                           |                                                                                                                                                                                                                 |
+| battleship                               | JSON            | 6e10df                    | Battleship example game                                                                                                                                                                                         |
+| intkey                                   | CBOR            | 1cf126                    | Integer Key. Full production example                                                                                                                                                                            |
+| smallbank                                | Protobuf        | 332514                    | Small Bank example app                                                                                                                                                                                          |
+| xo                                       | CSV-UTF8        | 5b7349                    | Tic-tac-toe example game                                                                                                                                                                                        |
+| supply_chain                             | Protobuf        | 3400de                    | Asset (Fish) Supply Chain example app                                                                                                                                                                           |
+| marketplace                              | Protobuf        | cd6744                    | Marketplace example app                                                                                                                                                                                         |
+| transfer- chain                          | JSON-UTF8       | 19d832                    | Simple Tuna Supply Chain app. Used for edX LFS171x class                                                                                                                                                        |
+| simplewallet                             | CSV-UTF8        | 7e2664                    | Simple Wallet minimal example                                                                                                                                                                                   |
+| cookiejar                                | CSV-UTF8        | a4d219                    | Cookie Jar minimal example                                                                                                                                                                                      |
+| simple_ supply                           | Protobuf        | 5d6af4                    | Simple Supply example used for future edX LFS201 class                                                                                                                                                          |
+| pirate-talk                              | UTF8            | aaaaaa                    | Pirate Talk minimal example                                                                                                                                                                                     |
+| cookie-maker                             | raw             | 1a5312                    | Cookie Maker minimal example                                                                                                                                                                                    |
+| SOME THIRD-PARTY PRODUCTION TFs          |                 |                           |                                                                                                                                                                                                                 |
+| rbac                                     | Protobuf        | 8563d0                    | T-Mobile NEXT Identity Platform                                                                                                                                                                                 |
+| sawtoothekyc                             | Protobuf        | dbf420                    | Primechain Blockchain-eKYC bank records                                                                                                                                                                         |
+| pub_key                                  | Protobuf        | a23be1                    | REMME REMChain                                                                                                                                                                                                  |
+| bitagora- ballots                        | JSON            | b42861                    | Bitagora voting ballot                                                                                                                                                                                          |
+| bitagora- polls                          | JSON            | 154f9c                    | Bitagora voting polls                                                                                                                                                                                           |
+
 [PREVIOUS](/faq/glossary/) [FAQ](/faq/) [NEXT](/faq/settings/)
-:::
 
 © Copyright 2018, Intel Corporation.

--- a/faq/rest.md
+++ b/faq/rest.md
@@ -1,15 +1,19 @@
-\-\--layout: page hide: true tags: \[faq\] title: Sawtooth FAQ - REST
-API permalink: /faq/rest/ \# Copyright (c) 2018, Intel Corporation. \#
-Licensed under Creative Commons Attribution 4.0 International License \#
-<https://creativecommons.org/licenses/by/4.0/> \-\--Sawtooth FAQ: REST
-API ====================== .. class:: mininav
+---
+layout: default
+hide: true
+tags: [faq]
+title: Sawtooth FAQ - REST
+API permalink: /faq/rest/
+# Copyright (c) 2018, Intel Corporation.
+# Licensed under Creative Commons Attribution 4.0 International License
+# <https://creativecommons.org/licenses/by/4.0/>
+---
+
+# Sawtooth FAQ: REST API
 
 [PREVIOUS](/faq/client/) [TOP](/faq/) [NEXT](/faq/permissioning/)
 
-::: contents
-:::
-
-# What\'s the difference between the `sawtooth-rest-api --bind` and `--connect` options?
+## What\'s the difference between the `sawtooth-rest-api --bind` and `--connect` options?
 
 `sawtooth-rest-api --bind` (`-B`)
 
@@ -21,12 +25,12 @@ API ====================== .. class:: mininav
 :   specifies where your rest-api can reach to the validator. The
     default is <http://localhost:4004>
 
-# Is the REST API at TCP port 8080 or 8008?
+## Is the REST API at TCP port 8080 or 8008?
 
 TCP Port 8008. It was 8080 before the 1.0 release and old examples and
 diagrams may use the old port number.
 
-# What REST API commands are available?
+## What REST API commands are available?
 
 Use localhost to access the REST API from the Validator Docker container
 or from where the Validator is running. For example, to get state
@@ -104,7 +108,7 @@ GET /peers
 For more information, see the Sawtooth REST API Reference at
 <https://sawtooth.hyperledger.org/docs/core/releases/latest/rest_api.html>
 
-# What is a transaction receipt?
+## What is a transaction receipt?
 
 Transaction receipts are transaction execution information that is not
 stored in state, such as how the transaction changed state, transaction
@@ -114,7 +118,7 @@ empty, but can be added by the TP with `context.add_receipt_data()` To
 access transaction receipts, use the REST API. For more information, see
 <https://sawtooth.hyperledger.org/docs/core/releases/latest/architecture/events_and_transactions_receipts.html#transaction-receipts>
 
-# How do I retrieve a transaction receipt?
+## How do I retrieve a transaction receipt?
 
 Use the REST API. Here\'s a sample request (The ID is the transaction
 ID, listed with [sawtooth transaction list]{.title-ref}):
@@ -128,28 +132,28 @@ For more than 15 IDs, use `POST /receipts` . For Receipts REST API
 details, see `receipts` at
 <https://sawtooth.hyperledger.org/docs/core/releases/latest/rest_api/endpoint_specs.html>
 
-# What does this error mean: `[... DEBUG route_handlers] Received CLIENT_STATE_GET_RESPONSE response from validator with status NO_RESOURCE`?
+## What does this error mean: `[... DEBUG route_handlers] Received CLIENT_STATE_GET_RESPONSE response from validator with status NO_RESOURCE`?
 
 It means the transaction processor for this transaction is not running.
 
-# What does this REST API error mean: `The submitted BatchList was rejected by the validator. It was poorly formed, or has an invalid signature`
+## What does this REST API error mean: `The submitted BatchList was rejected by the validator. It was poorly formed, or has an invalid signature`
 
 Most likey you are not putting the transaction into a batch or the batch
 in a batchlist for posting to the REST API. This is required, even for a
 single transaction.
 
-# I am getting this error: `Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at http://localhost:8008/batches?wait. (Reason: CORS header 'Access-Control-Allow-Origin' missing).`
+## I am getting this error: `Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at http://localhost:8008/batches?wait. (Reason: CORS header 'Access-Control-Allow-Origin' missing).`
 
 The Sawtooth REST API doesn\'t support CORS. To allow cross-origin
 access to the Sawtooth API, put it behind a proxy.
 
-# What does this error mean: `Request failed with status code 429`
+## What does this error mean: `Request failed with status code 429`
 
 To avoid DDoS attacks (too many requests from a single source), Sawtooth
 has a mechanism called \"backpressure test\" which avoids such things as
 excessive network traffic and excessive Sawtooth transactions.
 
-# What is the back pressure test?
+## What is the back pressure test?
 
 Back pressure is a flow-control technique to help prevent DoS attacks.
 It results in a `Status.QUEUE_FULL` client batch submit response or a
@@ -159,7 +163,7 @@ work. The number of batches that validator can accept is based on a
 multiplier, QUEUE_MULTIPLIER (currently 10, formerly 2), times a rolling
 average of the number of published batches.
 
-# Can I disable the back pressure test?
+## Can I disable the back pressure test?
 
 No. There isn\'t a way to disable that currently because it\'s
 determined based on a multiplier of the publishing rate of the network.
@@ -170,13 +174,11 @@ this feature it is trivial to do a client-based attack which overwhelms
 the network creating a DoS. You would have to make a custom build of
 Sawtooth to remove that check.
 
-# What does this error mean from sawset: `There is no resource with the identifier`?
+## What does this error mean from sawset: `There is no resource with the identifier`?
 
 It means the command format is correct, but the identifier does not
 exist.
 
-::: mininav
 [PREVIOUS](/faq/client/) [TOP](/faq/) [NEXT](/faq/permissioning/)
-:::
 
 © Copyright 2018, Intel Corporation.

--- a/faq/rest.md
+++ b/faq/rest.md
@@ -8,7 +8,6 @@ API permalink: /faq/rest/
 # Licensed under Creative Commons Attribution 4.0 International License
 # <https://creativecommons.org/licenses/by/4.0/>
 ---
-
 # Sawtooth FAQ: REST API
 
 [PREVIOUS](/faq/client/) [TOP](/faq/) [NEXT](/faq/permissioning/)

--- a/faq/sawtooth.md
+++ b/faq/sawtooth.md
@@ -1,17 +1,19 @@
-\-\--layout: page hide: true tags: \[faq\] title: Sawtooth FAQ -
-Hyperledger Sawtooth in General permalink: /faq/sawtooth/ \# Copyright
-(c) 2018, Intel Corporation. \# Licensed under Creative Commons
-Attribution 4.0 International License \#
-<https://creativecommons.org/licenses/by/4.0/> \-\--Sawtooth FAQ:
-Hyperledger Sawtooth in General
-============================================= .. class:: mininav
+---
+layout: default
+hide: true
+tags: [faq]j
+title: Sawtooth FAQ - Hyperledger Sawtooth in General
+permalink: /faq/sawtooth/
+# Copyright (c) 2018, Intel Corporation.
+# Licensed under Creative Commons Attribution 4.0 International License
+# <https://creativecommons.org/licenses/by/4.0/>
+---
+
+# Sawtooth FAQ: Hyperledger Sawtooth in General
 
 [TOP](/faq/) [NEXT](/faq/installation/)
 
-::: contents
-:::
-
-# What is Sawtooth?
+## What is Sawtooth?
 
 Hyperledger Sawtooth is a modular enterprise blockchain platform for
 building, deploying, and running distributed ledgers. The design
@@ -22,7 +24,7 @@ which targets large distributed validator populations with minimal
 resource consumption. No special hardware is required to run Sawtooth or
 PoET.
 
-# What are some useful Sawtooth links?
+## What are some useful Sawtooth links?
 
 Sawtooth introduction
 
@@ -68,7 +70,7 @@ Sawtooth FAQ
 
 :   <https://github.com/danintel/sawtooth-faq>
 
-# Where are some good introductory videos?
+## Where are some good introductory videos?
 
 Hyperledger Sawtooth 1.0: Market Significance & Technical Overview (Hyperledger, 2018, 61:27) (free registration required):
 
@@ -83,13 +85,13 @@ You can find several more here:
 
 :   <https://www.youtube.com/results?search_query=Hyperledger+Sawtooth>
 
-# Where are some good advanced videos?
+## Where are some good advanced videos?
 
 A list of Hyperledger Sawtooth [videos](/faq/videos/) (mostly Sawtooth
 Technical Forum recordings) are at
 <https://github.com/danintel/sawtooth-faq/blob/master/settings.rst>
 
-# What courses are available on Hyperledger Sawtooth?
+## What courses are available on Hyperledger Sawtooth?
 
 -   B9Lab has a five-week Sawtooth Developer training course. See
     <https://academy.b9lab.com/courses/B9lab/current-sawtooth-course>
@@ -110,13 +112,13 @@ Technical Forum recordings) are at
     Administrator (CHSA) course. See
     <https://www.blockchaineducators.org/hyperledger/>
 
-# What Sawtooth exams are available?
+## What Sawtooth exams are available?
 
 A Certified Hyperledger Sawtooth Administrator (CHSA) exam is available
 at
 <https://www.hyperledger.org/resources/training/hyperledger-sawtooth-certification>
 
-# Are there any example applications based on Sawtooth?
+## Are there any example applications based on Sawtooth?
 
 A simple application that implements a cookie jar showing just the Sawtooth API:
 
@@ -134,7 +136,7 @@ An example application that shows how to exchange quantities of customized \"Ass
 
 :   <https://github.com/hyperledger/sawtooth-marketplace>
 
-# Are there any live demos of a Sawtooth Application?
+## Are there any live demos of a Sawtooth Application?
 
 Yes. A Sawtooth Supply Chain demo, AssetTrack is at
 <https://demo.bitwise.io/> . Another demo, for tracking fish, is at
@@ -143,7 +145,7 @@ Yes. A Sawtooth Supply Chain demo, AssetTrack is at
 is at <https://provenance.sawtooth.me/> . The source and docs are at
 <https://github.com/hyperledger/sawtooth-marketplace/>
 
-# What is the Hyperledger Sawtooth Application Developers Forum?
+## What is the Hyperledger Sawtooth Application Developers Forum?
 
 It is to provide opportunities to discuss technical application
 development questions with developers experienced with Hyperledger
@@ -153,7 +155,7 @@ Thursday at 2pm India Time. For details and current contact information
 for both forums, see <https://chat.hyperledger.org/channel/sawtooth> for
 details.
 
-# What is the difference between Hyperledger and Sawtooth?
+## What is the difference between Hyperledger and Sawtooth?
 
 -   Sawtooth (or Hyperledger Sawtooth) is a blockchain implementation
     initially contributed by Intel Corporation and now maintained by the
@@ -169,7 +171,7 @@ details.
     technologies. It is a global collaboration, hosted by The Linux
     Foundation\" See <https://www.hyperledger.org/>.
 
-# What is the difference between Sawtooth, Sawtooth Lake, and Hyperledger Sawtooth?
+## What is the difference between Sawtooth, Sawtooth Lake, and Hyperledger Sawtooth?
 
 Sawtooth Lake was Intel\'s original code name for its blockchain
 research project, named after a lake in the Sawtooth Mountains of
@@ -178,7 +180,7 @@ Hyperledger consortium, the name was changed to Hyperledger Sawtooth.
 Sawtooth is just shorthand for Hyperledger Sawtooth and are the same
 thing.
 
-# What is the difference between Hyperledger Sawtooth and Hyperledger Fabric?
+## What is the difference between Hyperledger Sawtooth and Hyperledger Fabric?
 
 Hyperledger Sawtooth and Fabric are two independent implementations of a
 blockchain under the Linux Foundation\'s Hyperledger Blockchain project.
@@ -202,7 +204,7 @@ Here are some differences:
 
 Based on <https://www.skcript.com/svr/hyperledger-fabric-to-sawtooth>
 
-# What differentiates Sawtooth from other blockchains?
+## What differentiates Sawtooth from other blockchains?
 
 This includes:
 
@@ -217,13 +219,13 @@ This includes:
 For more on Sawtooth differentiation and philosophy, see
 <https://www.hyperledger.org/blog/2016/11/02/meet-sawtooth-lake>
 
-# Should I use Sawtooth or other blockchain software for my application?
+## Should I use Sawtooth or other blockchain software for my application?
 
 You should look for existing blockchain platforms that will fit your use
 case, sort them out by features, maturity (are they production ready?),
 and community support. We hope Sawtooth fits your needs.
 
-# How does a blockchain differ from a database?
+## How does a blockchain differ from a database?
 
 -   A database has one master copy. A blockchain has multiple
     authoritative copies
@@ -231,12 +233,12 @@ and community support. We hope Sawtooth fits your needs.
     are immutable and cannot be undone after a commit
 -   A database must have a trusted central authority
 
-# Does Sawtooth focus on developing blockchain solutions for sustainable fishing?
+## Does Sawtooth focus on developing blockchain solutions for sustainable fishing?
 
 No. The Seafood Supply Chain application is a proof-of-concept. Sawtooth
 is a general-purpose enterprise blockchain platform.
 
-# What does an immutable blockchain mean?
+## What does an immutable blockchain mean?
 
 It means that blocks already committed cannot be \"undone\" or deleted.
 The block\'s transactions are in the blockchain forever. The only way to
@@ -252,14 +254,14 @@ This is different from immutable variables. The difference is that with
 blockchain *transactions* are immutable. With some programming languages
 (such as Rust), *variables* are immutable.
 
-# How do I tell what version of Sawtooth is running?
+## How do I tell what version of Sawtooth is running?
 
 ``` sh
 $ sawtooth --version
 sawtooth-cli (Hyperledger Sawtooth) version 1.1.2
 ```
 
-# What\'s the difference between the `sawtooth`, `sawadm`, `sawnet`, and `sawset` commands?
+## What\'s the difference between the `sawtooth`, `sawadm`, `sawnet`, and `sawset` commands?
 
 `sawadm`
 
@@ -285,24 +287,24 @@ sawtooth-cli (Hyperledger Sawtooth) version 1.1.2
 For more information, see the Sawtooth CLI Command Reference at
 <https://sawtooth.hyperledger.org/docs/core/releases/latest/cli.html>
 
-# Must software developed with Sawtooth be open source?
+## Must software developed with Sawtooth be open source?
 
 IANAL; however, Sawtooth is released under the Apache 2 license, a
 permissive license, and so should be able to be used in both open and
 closed source applications.
 
-# Can I copy a Sawtooth Core source file to include with my project?
+## Can I copy a Sawtooth Core source file to include with my project?
 
 Yes, if you follow the Apache 2 license terms, which include requiring
 preserving copyright and license notices. Sawtooth depends on other
 runtime software that has separate terms.
 
-# I get a usage error running `sawnet peers` or `sawnet list-blocks`
+## I get a usage error running `sawnet peers` or `sawnet list-blocks`
 
 These commands were added after the Sawtooth 1.0.5 release and are not
 available in earlier releases.
 
-# How do I detect a forked blockchain in a Sawtooth network?
+## How do I detect a forked blockchain in a Sawtooth network?
 
 Use [sawnet compare-chains]{.title-ref} and look for a different set of
 block(s) at the head of the chains. This is distinct from the case where
@@ -312,26 +314,26 @@ partitioned and cannot fully communicate. It can also be the result of a
 bug in transaction processing (for example, transactions don\'t
 serialize in a deterministic way).
 
-# What does `Failed to reach common ancestor` mean from `sawnet compare-chains`?
+## What does `Failed to reach common ancestor` mean from `sawnet compare-chains`?
 
 It means the blockchains have no blocks in common, including the genesis
 block. This usually happens when a second node is added with its own
 genesis node. Only the first node in a Sawtooth network should be
 created with a genesis block.
 
-# Does Hyperledger Composer support Sawtooth?
+## Does Hyperledger Composer support Sawtooth?
 
 No. IBM has also reduced Composer development to maintenance mode. See:
 <https://lists.hyperledger.org/g/composer/message/125>
 
-# Does Hyperledger Explorer support Sawtooth?
+## Does Hyperledger Explorer support Sawtooth?
 
 No, not now. There is a Sawtooth Explorer at
 <https://github.com/hyperledger/sawtooth-explorer> It may or may not be
 merged with Hyperledger Explorer in the future. Sawtooth Explorer
 provides visibility into the Sawtooth blockchain for node operators.
 
-# How do I setup and use Sawtooth Explorer?
+## How do I setup and use Sawtooth Explorer?
 
 -   Install, configure, and run Hyperledger Sawtooth
 -   Clone Sawtooth Explorer with
@@ -350,18 +352,18 @@ provides visibility into the Sawtooth blockchain for node operators.
 -   More details are at
     <https://github.com/hyperledger/sawtooth-explorer>
 
-# How do I report a bug?
+## How do I report a bug?
 
 Use the JIRA bug tracking system at
 <https://jira.hyperledger.org/projects/STL/issues/STL-51?filter=allopenissues>
 You need an account, which you create with the Linux foundation at
 <https://identity.linuxfoundation.org/>, then login with that account.
 
-# How do I report a security bug?
+## How do I report a security bug?
 
 For security bugs only, send an email to <security@hyperledger.org>
 
-# What encryption algorithms are used by Sawtooth?
+## What encryption algorithms are used by Sawtooth?
 
 -   Transaction signing with ECDSA 256-bit key using curve secp256k1
     (same as Bitcoin)
@@ -371,7 +373,7 @@ For security bugs only, send an email to <security@hyperledger.org>
 -   PoET uses AES-GCM to encrypt its monotonic counter
 -   Names are hashed with SHA-512 or SHA-256
 
-# Can you explain Global State with an example?
+## Can you explain Global State with an example?
 
 Global state is where sawtooth and TPs read/write blockchain data.
 Examples are a-plenty if you look at the github repo examples (intkey,
@@ -392,7 +394,7 @@ state will contain the balance in the different accounts corresponding
 at the current point in time, after all transactions in the chain have
 been processed.
 
-# What is the difference between the Merkle Radix Trie and the blockchain?
+## What is the difference between the Merkle Radix Trie and the blockchain?
 
 The blockchain itself just stores transactions, not state, so reading
 the data in the last block does not say much by itself. Data in the
@@ -403,14 +405,14 @@ One can easily identify if something changed when the root hash changes.
 The Merkle Trie addressing allows quick retrieval at an address and
 partial queries of address prefixes.
 
-# Are 32-byte IDs within a transaction family large enough to avoid collisions?
+## Are 32-byte IDs within a transaction family large enough to avoid collisions?
 
 Yes. If they are being generated with a random distribution, the chances
 are vanishingly rare. A UUID is only 16-bytes and if you generated a
 billion per second, it would take 100 years before you would expect 50%
 odds of a collision.
 
-# Why is Sawtooth capable of supporting large network populations of nodes?
+## Why is Sawtooth capable of supporting large network populations of nodes?
 
 One of the reasons is the homogeneous nature of Sawtooth Nodes. You
 don\'t have different nodes with specialized functions, so it\'s easy to
@@ -420,13 +422,13 @@ efficient in small networks and you\'ll likely get much better
 performance with other mechanisms in a small network, but PoET handles
 large populations easily.
 
-# Is there a Sawtooth security evaluation?
+## Is there a Sawtooth security evaluation?
 
 Yes. This is a pre-1.0 release audit, that was required to be a part of
 the Linux Foundation\'s Hyperledger project. See
 <https://www.hyperledger.org/blog/2018/05/22/hyperledger-sawtooth-security-audit>
 
-# Are there any examples of Sawtooth permissions?
+## Are there any examples of Sawtooth permissions?
 
 -   off-chain permissioning is in `/etc/sawtooth/validator.toml` (see
     `validator.toml.example` )
@@ -445,11 +447,11 @@ the Linux Foundation\'s Hyperledger project. See
     Identity Transaction Processor, documented at
     <https://sawtooth.hyperledger.org/docs/core/releases/latest/transaction_family_specifications/identity_transaction_family.html>
 
-# Does Sawtooth restore state when a peer restarts or when a peer is out-of-sync with the network?
+## Does Sawtooth restore state when a peer restarts or when a peer is out-of-sync with the network?
 
 Yes.
 
-# When content at an address is changed several times by the transactions in a block, what appears in the state (Merkle Tree)?
+## When content at an address is changed several times by the transactions in a block, what appears in the state (Merkle Tree)?
 
 The only thing that hits state is the aggregate (final) set of address
 changes due to the transactions in the block. If multiple transactions
@@ -457,7 +459,7 @@ in a single block modify an address, there will only be one \'set\'. You
 could see the transaction level changes in the receipts if you needed
 to.
 
-# In order to create a Sawtooth application, do I need to clone and modify the entire `sawtooth-core` repository?
+## In order to create a Sawtooth application, do I need to clone and modify the entire `sawtooth-core` repository?
 
 No. It can be done that way, but it\'s not recommended. All you need to
 write is the client application and the Transaction Processor. The core
@@ -474,7 +476,7 @@ simple sample applications that are in standalone source repositories:
     This will be the example in a future edX.org course on Sawtooth app
     development
 
-# What is Sawtooth *global state agreement*?
+## What is Sawtooth *global state agreement*?
 
 Sawtooth writes state to a verifiable structure called a *Radix Merkle
 Trie* and the verification part (the root hash) is included in the
@@ -492,7 +494,7 @@ a production network, but it is also helpful during development. Running
 applications over test networks can help identify nondeterminism and
 that will only be apparent if you form consensus over state.
 
-# How can CPU vulnerabilities such as Spectre and Meltdown impact Sawtooth?
+## How can CPU vulnerabilities such as Spectre and Meltdown impact Sawtooth?
 
 Sawtooth is a CPU-agnostic blockchain platform. It includes an optional
 TEE/SGX feature which enhances BFT protections for PoET. PoET is
@@ -515,7 +517,7 @@ transactions. If it does the other nodes will just reject those
 transactions and the associated block(s) and they will not commit
 network-wide.
 
-# Are Docker containers required to run Sawtooth?
+## Are Docker containers required to run Sawtooth?
 
 Docker is a quick and easy way to get Sawtooth up and running. However,
 unlike other Hyperledger ledgers, Sawtooth does not require Docker.
@@ -543,19 +545,19 @@ commands in a `Dockerfile` as follows:
 -   Start your application client (see `CMD` in your client
     `Dockerfile`)
 
-# What cloud services support Sawtooth Blockchain?
+## What cloud services support Sawtooth Blockchain?
 
 AWS offers Sawtooth, and other cloud providers plan to offer Sawtooth on
 their cloud service.
 
-# Does Sawtooth support Ethereum?
+## Does Sawtooth support Ethereum?
 
 Yes, through Seth, Sawtooth\'s Ethereum-compatible Transaction
 Processor. It implements a Ethereum Virtual Machine (EVM) so Seth can
 run Ethereum Dapps written in Solidity. Seth uses Hyperledger Burrow as
 the code base.
 
-# Does Sawtooth use blockchain mining?
+## Does Sawtooth use blockchain mining?
 
 No. There is no inherent need to incentivize miners in a
 private/permissioned blockchain. Part of the permissioned model is that
@@ -565,7 +567,7 @@ you are asking strangers to verify the data for you. In that case you
 probably do need to incentivize them somehow, and a currency is a common
 way to do so.
 
-# What is the \"head node\" or \"master node\" in Sawtooth?
+## What is the \"head node\" or \"master node\" in Sawtooth?
 
 Sawtooth has no concept of a \"head node\" or \"master node\". Once
 multiple nodes are up and running, each node has the same genesis block
@@ -573,7 +575,7 @@ multiple nodes are up and running, each node has the same genesis block
 on the network has no special meaning, other than being the node that
 created the genesis block.
 
-# What is a Sawtooth Role?
+## What is a Sawtooth Role?
 
 A Role is a set if permissions. Identities could be assigned one or more
 roles. A role is a convenient shorthand because role(s) can be assigned
@@ -581,7 +583,7 @@ to several identities rather than tediously assigning individual
 permissions to each identity. See
 <https://sawtooth.hyperledger.org/docs/core/nightly/master/sysadmin_guide/configuring_permissions.html>
 
-# What Sawtooth Roles are defined?
+## What Sawtooth Roles are defined?
 
 transactor
 
@@ -607,8 +609,6 @@ network.consensus
 
 :   nodes authorized to broadcast new blocks with Gossip
 
-::: mininav
 [TOP](/faq/) [NEXT](/faq/installation/)
-:::
 
 © Copyright 2018, Intel Corporation.

--- a/faq/settings.md
+++ b/faq/settings.md
@@ -1,14 +1,17 @@
-\-\--layout: page hide: true tags: \[appendix\] title: \"Appendix:
-Sawtooth Settings\" permalink: /faq/settings/ \# Copyright (c) 2018,
-Intel Corporation. \# Licensed under Creative Commons Attribution 4.0
-International License \# <https://creativecommons.org/licenses/by/4.0/>
-\-\--FAQ Appendix: Configuration Settings
-==================================== .. class:: mininav
+---
+layout: default
+hide: true
+tags: [appendix]
+title: "Appendix: Sawtooth Settings"
+permalink: /faq/settings/
+# Copyright (c) 2018, Intel Corporation.
+# Licensed under Creative Commons Attribution 4.0 International License
+# <https://creativecommons.org/licenses/by/4.0/>
+---
+
+# FAQ Appendix: Configuration Settings
 
 [PREVIOUS](/faq/prefixes/) [FAQ](/faq/) [NEXT](/faq/videos/)
-
-::: contents
-:::
 
 This is an unofficial list of some Transaction Family (TF) settings.
 There is no central registry, most or all of these can be found on
@@ -288,8 +291,6 @@ transactor.transaction_signer.xo
 
 :   Public keys of authorized xo TF signers
 
-::: mininav
 [PREVIOUS](/faq/prefixes/) [FAQ](/faq/) [NEXT](/faq/videos/)
-:::
 
 © Copyright 2018, Intel Corporation.

--- a/faq/transaction-processing.md
+++ b/faq/transaction-processing.md
@@ -1,17 +1,19 @@
-\-\--layout: page hide: true tags: \[faq\] title: Sawtooth FAQ -
-Transaction Processing permalink: /faq/transaction-processing/ \#
-Copyright (c) 2018, Intel Corporation. \# Licensed under Creative
-Commons Attribution 4.0 International License \#
-<https://creativecommons.org/licenses/by/4.0/> \-\--Sawtooth FAQ:
-Transaction Processing ==================================== .. class::
-mininav
+---
+layout: default
+hide: true
+tags: [faq]
+title: Sawtooth FAQ - Transaction Processing
+permalink: /faq/transaction-processing/
+# Copyright (c) 2018, Intel Corporation.
+# Licensed under Creative Commons Attribution 4.0 International License
+# <https://creativecommons.org/licenses/by/4.0/>
+---
+
+# Sawtooth FAQ: Transaction Processing
 
 [PREVIOUS](/faq/installation/) [TOP](/faq/) [NEXT](/faq/validator/)
 
-::: contents
-:::
-
-# Does a client send a transaction request to all the validators in the network?
+## Does a client send a transaction request to all the validators in the network?
 
 No, it would just need to send the batch to one validator, then that
 validator will broadcast the batch to the rest of its peers. If the
@@ -19,18 +21,18 @@ validator is down, your connection attempt from the app would fail. The
 app could have error handling to try again (in a retry loop) or try
 another validator.
 
-# Does Sawtooth have a way to control what participants have access to what assets in the business network and under what conditions?
+## Does Sawtooth have a way to control what participants have access to what assets in the business network and under what conditions?
 
 Blockchains, including Sawtooth, can be deployed as permissioned
 networks, wherein transactions are visible to the participants of the
 permissioned network, but not visible to the general public.
 
-# What transaction processors are required?
+## What transaction processors are required?
 
 Just the Settings TP, `settings` . The Validator Registry TP,
 `sawtooth_validator_registry` , is required if you use PoET.
 
-# What does the Settings TP do?
+## What does the Settings TP do?
 
 The Settings TP provides on-chain configs to be applied to the Sawtooth
 Validators, so that you can change operational parameters without
@@ -38,19 +40,19 @@ restarting the validators or the whole sawtooth network. Also, you could
 write your own settings-tp, that stores the settings the same way but
 enforces different rules on how they are updated.
 
-# Is there an example where the Settings TP is used in another TP?
+## Is there an example where the Settings TP is used in another TP?
 
 Yes. check out `sawtooth.identity.allowed_keys` in the Identity TP:
 <https://github.com/hyperledger/sawtooth-core/blob/master/families/identity/sawtooth_identity/processor/handler.py>
 
-# Can different Validator Nodes have different Transaction Processors running?
+## Can different Validator Nodes have different Transaction Processors running?
 
 No. The set of TPs must be the same for all validator nodes in a
 Sawtooth network. The TP versions must also match across nodes\--support
 the same set of ops. This is so the transaction and state validation
 will be successful.
 
-# How do I support multiple versions of a Transaction Processor?
+## How do I support multiple versions of a Transaction Processor?
 
 You have two choices:
 
@@ -62,21 +64,21 @@ You have two choices:
 In any case, all nodes need to support the same set of versions for a
 specific Transaction Family.
 
-# How do I support multiple Transaction Families in a Transaction Processor?
+## How do I support multiple Transaction Families in a Transaction Processor?
 
 This is usually not a preferred best practice. But if the functionality
 of the different TFs are closely related, you can have a TP support
 multiple TFs. Just have the TP register multiple TFs at startup, instead
 of just one TF.
 
-# How do I upgrade a transaction processor version?
+## How do I upgrade a transaction processor version?
 
 Bump up the version number of the TP and register with the validator.
 Submit transactions to the TP with the updated version number. If you
 want to reuse the existing TP, then you\'ll need to stop the existing
 one and register the new one.
 
-# Can a Validator Node have multiple TPs (processes) running for the same TF?
+## Can a Validator Node have multiple TPs (processes) running for the same TF?
 
 Yes, one or more TPs, handling the same or different Transaction
 Families, may be running and register with a validator. This is one way
@@ -84,7 +86,7 @@ to achieve parallelism. Another way to achieve parallelism is to write a
 multi-threaded TP. The transactions are sent to transaction processors
 supporting the same transaction family in a round-robin fashion.
 
-# What are inputs and outputs in Sawtooth?
+## What are inputs and outputs in Sawtooth?
 
 In a Sawtooth transaction, inputs list what are the inputs for the
 transaction (what addresses the TP can read). Outputs list what are the
@@ -92,20 +94,20 @@ outputs for the transaction (what addresses the TP can modify). The
 inputs and outputs lists are specific to a transaction. See
 <https://sawtooth.hyperledger.org/docs/core/releases/latest/architecture/transactions_and_batches.html>
 
-# Why use round-robin if the transaction processors are identical?
+## Why use round-robin if the transaction processors are identical?
 
 This is useful when the when the validator\'s parallel scheduler is
 used. Multiple transactions can be processed in parallel when the
 inputs/outputs do not conflict.
 
-# Where do I deploy transaction processors?
+## Where do I deploy transaction processors?
 
 Each validator node runs all transaction processors supported for the
 Sawtooth network. Sawtooth includes features for asynchronously
 deploying and upgrading the Transaction Processors. In a typical
 deployment you will have multiple Transaction Processors.
 
-# What happens if a validator receives a transaction but does not have a TP for it?
+## What happens if a validator receives a transaction but does not have a TP for it?
 
 If a validator receives a transaction that it does not have a
 transaction processor for, the validator will wait until a TP connects
@@ -118,20 +120,20 @@ transitions that include or depend on such transactions *until* the
 transaction processor is deployed for that node. Once deployed on that
 validator, the validator will be able to catch up with the network.
 
-# How can I limit what Transaction Processors run on a Validator Node?
+## How can I limit what Transaction Processors run on a Validator Node?
 
 You can also limit which transactions are accepted on the network by
 setting `sawtooth.validator.transaction_families` If that setting is not
 set, all transaction processors are accepted. This setting is ignored in
 dev-mode consensus.
 
-# Where do transactions originate?
+## Where do transactions originate?
 
 From the client. The client sends a transaction to a validator, in a
 batch with one or more transactions. The transactions are sent to the
 validator, via the REST API, for the validator to add to the blockchain.
 
-# Can the same transaction appear in multiple blocks?
+## Can the same transaction appear in multiple blocks?
 
 No. Each block has a unique set of transaction. A block is composed of
 batches, which is composed of transactions. Each transaction has a
@@ -139,7 +141,7 @@ unique ID and appears only once in a blockchain. There may be, however,
 differences in ordering of blocks at a validator due to scheduling,
 transaction dependencies, etc.
 
-# What mechanism prevents a rogue TP from operating and corrupting data?
+## What mechanism prevents a rogue TP from operating and corrupting data?
 
 The design is as such that rogue TPs can\'t harm legitimate TPs. When
 you run a network of validators, each validator has to have same version
@@ -150,12 +152,12 @@ fail state validations(Merkle hashes will be different with rest of the
 network). Hence, the bigger the validator network, the more robust it is
 against such attacks.
 
-# What does this error mean: `processor | [... DEBUG executor] transaction processors registered for processor type cryptomoji: 0.1?`
+## What does this error mean: `processor | [... DEBUG executor] transaction processors registered for processor type cryptomoji: 0.1?`
 
 It means there is no transaction processor running for your transaction
 family.
 
-# What does this error mean: `processor | { AuthorizationException: Tried to get unauthorized address ...` ?
+## What does this error mean: `processor | { AuthorizationException: Tried to get unauthorized address ...` ?
 
 It means a the transaction processor tried to access (get/put) a value
 not in the list of inputs/outputs. This occurs when a client submits a
@@ -165,30 +167,30 @@ Make sure the Sawtooth address is the correct length\--the address is 70
 hex characters, which represent a 35 byte address (including the 6 hex
 character or 3 byte Transaction Family prefix).
 
-# What does this error mean: `applicator->Apply errorState Get Authorization error. Check transaction inputs.`
+## What does this error mean: `applicator->Apply errorState Get Authorization error. Check transaction inputs.`
 
 See the answer above.
 
-# If you have a large file to store, is it best to just record the file hash and store the file offline?
+## If you have a large file to store, is it best to just record the file hash and store the file offline?
 
 It depends on your use case. Storing data off-chain has a big downside.
 Although you can confirm it hasn\'t been tampered with with the on-chain
 hash, there is nothing stopping the file from disappearing. Also, how do
 you make sure everyone who needs the data can get to it?
 
-# If I register a transaction processor to one validator, does the registration get transmitted to the other validators in a network?
+## If I register a transaction processor to one validator, does the registration get transmitted to the other validators in a network?
 
 No. Your transaction processor must be deployed to all validators. All
 validators in a network must have the same set of transaction
 processors.
 
-# How do I add a transaction processor?
+## How do I add a transaction processor?
 
 You just start it in for all the validator nodes. The TP needs to
 connect to `tcp://localhost:4004` or, if you are using Docker,
 `tcp://validator:4004`
 
-# How do I restrict what transaction processors are allowed?
+## How do I restrict what transaction processors are allowed?
 
 By default, any TP can be added to a node without special permission
 (other than network access). To restrict what TPs can be added to a
@@ -197,14 +199,14 @@ validator, use `sawset proposal create` to set
 `Configuring the List of Transaction Families` at
 <https://sawtooth.hyperledger.org/docs/core/releases/latest/app_developers_guide/docker.html>
 
-# How do I add events to the transaction processor?
+## How do I add events to the transaction processor?
 
 In the TP code, call `context.add_event()`. This adds a an
 application-specific event. In the client code (or other app for
 listening), subscribe to the event. For details, see
 <https://sawtooth.hyperledger.org/docs/core/releases/latest/architecture/events_and_transactions_receipts.html#events>
 
-# What initial Sawtooth events are available?
+## What initial Sawtooth events are available?
 
 Besides application-specific events, the Sawtooth default events are:
 
@@ -217,7 +219,7 @@ Besides application-specific events, the Sawtooth default events are:
 
 :   All state changes that occurred for a block at a specific address
 
-# How do I subscribe to Sawtooth events?
+## How do I subscribe to Sawtooth events?
 
 See the documentation at
 <https://sawtooth.hyperledger.org/docs/core/nightly/master/app_developers_guide/event_subscriptions.html>
@@ -226,7 +228,7 @@ Here are examples in Python and Javascript:
 -   <https://github.com/danintel/sawtooth-cookiejar/blob/master/events/events_client.py>
 -   <https://github.com/hyperledger/sawtooth-supply-chain/blob/master/ledger_sync/subscriber/index.js>
 
-# How do I handle forks while subscribing to Sawtooth events?
+## How do I handle forks while subscribing to Sawtooth events?
 
 If you get `fork_detected: true` in the `state_changes` object, you
 delete or undo events labeled with the blocks that have been removed
@@ -234,13 +236,13 @@ from history. For example, if you added the events to a local database,
 remove the rows labeled with the removed blocks. Then apply events
 forward from the most recent common block.
 
-# Why is the Apply method in the TP handler called twice?
+## Why is the Apply method in the TP handler called twice?
 
 That is by design. It can be called more than twice. For that reason,
 the TP handler must be deterministic (have the same output results given
 the same input).
 
-# What does it mean to be deterministic?
+## What does it mean to be deterministic?
 
 Deterministic means the output never varies, given the same input. That
 is,
@@ -253,11 +255,11 @@ is,
 -   counters, likewise, generated by the TP are not allowed (but
     counters from the client are OK for a given transaction)
 
-# Do Transaction Processors run off-chain or on-chain?
+## Do Transaction Processors run off-chain or on-chain?
 
 Sawtooth TPs run off-chain, as a process (or processes).
 
-# My TP throws an exception of type `InternalError`, but the `Apply` method gets stuck in an endless loop
+## My TP throws an exception of type `InternalError`, but the `Apply` method gets stuck in an endless loop
 
 `InternalError` is supposed to be a transient error (some internal fault
 like \'out of memory\' that is temporary), and may succeed if retried.
@@ -266,7 +268,7 @@ If the transaction is invalid, you probably want to raise an
 `InvalidTransaction` error instead. Bottom line&mdash;internal errors
 are retried, and invalid transactions are not retried.
 
-# I get this error when I try to set some Sawtooth settings: `Chain head is not set yet. Permit all`
+## I get this error when I try to set some Sawtooth settings: `Chain head is not set yet. Permit all`
 
 This error has been seen when the directory or file ownerships are
 wrong. Try setting ownership as follows:
@@ -276,23 +278,23 @@ because the Settings TP has not been started. Start with
 `settings-tp -vv` . Another cause could be because there is no genesis
 block.
 
-# Does the Transaction Processor know the current Transaction ID?
+## Does the Transaction Processor know the current Transaction ID?
 
 Yes. It is available in the header. The transaction header_signature is
 the Transaction ID.
 
-# Can I run two different Transaction Processors on the same Sawtooth Network?
+## Can I run two different Transaction Processors on the same Sawtooth Network?
 
 Yes, you can run any number of transaction families, for example, you
 can r un the Seafood Supply Chain app and Bond Asset Settlement app on
 the same network.
 
-# What happens if someone writes a fake Transaction Processor (with the same name, version, and address space) that can access and modify state data?
+## What happens if someone writes a fake Transaction Processor (with the same name, version, and address space) that can access and modify state data?
 
 The fake TP will cause the node to fork and it will be ignored by the
 rest of the network.
 
-# Why is there no timestamp in a transaction header or block?
+## Why is there no timestamp in a transaction header or block?
 
 Using timestamps in a distributed network is troublesome\--mostly due to
 complex clock synchronization issues among peers. You could add a
@@ -303,7 +305,7 @@ inject BlockInfo transactions using the BlockInfo Transaction Family
 (which is used for EVM compatibility). See:
 <https://sawtooth.hyperledger.org/docs/core/releases/latest/transaction_family_specifications/blockinfo_transaction_family.html>
 
-# Does Sawtooth allow multiple digital signatures on a single transaction?
+## Does Sawtooth allow multiple digital signatures on a single transaction?
 
 In Sawtooth the \"batch\" is the atomic unit of change. This is a
 collection of one or more individually signed transactions. You could
@@ -313,7 +315,7 @@ about I think. You can also build whatever app logic you like. So you
 can require transactions from multiple parties before an action is
 taken. The individual transactions themselves have only one signer.
 
-# What is the size limit for a Sawtooth transaction?
+## What is the size limit for a Sawtooth transaction?
 
 There is no size limit, barring any memory and storage limits for your
 Sawtooth nodes.
@@ -322,7 +324,7 @@ If you don\'t want to write a large transaction, you can reference some
 external source (and also save a checksum). The disadvantage of storing
 data externally is it\'s not replicated across nodes and may be lost.
 
-# What does this message mean: `Did not respond to the ping, removing transaction processor` ?
+## What does this message mean: `Did not respond to the ping, removing transaction processor` ?
 
 This is a message from the Hyperledger Sawtooth blockchain\'s Validator.
 A timeout occurred when the Validator was checking connections with all
@@ -346,14 +348,14 @@ Python (or another language you use for the TP). Start the transaction
 processor with the ]{.title-ref}[-vv]{.title-ref}[ or
 ]{.title-ref}[-vvv]{.title-ref}\` flags and look for console output.
 
-# What does this message mean: `failing transaction ... since it isn't required in the configuration` ?
+## What does this message mean: `failing transaction ... since it isn't required in the configuration` ?
 
 It means you set the `sawtooth.validator.transaction_families` setting
 with the Settings TP and did not include the TP name and version for the
 transaction that failed. The fix is to add the TP name and version to
 the setting.
 
-# I noticed that TPs on various nodes do not process transactions in the same order. Why?
+## I noticed that TPs on various nodes do not process transactions in the same order. Why?
 
 There is no guarantee of sequencing in terms of how different
 transactions are submitted and executed by the TPs. When transactions
@@ -363,7 +365,7 @@ validator\'s scheduler understands the ordering relationship and needs
 to apply each state transition to the context provided to the next
 transaction\'s execution.
 
-# What do `failed state root hash validation` errors mean?
+## What do `failed state root hash validation` errors mean?
 
 You have something non-deterministic happening with your changes to
 state. You should not do non-deterministic actions in your transaction
@@ -374,8 +376,6 @@ prior to setState calls in your transaction processor. There will likely
 be a difference between the publishing and validation executions of the
 transaction (they always need to be identical)
 
-::: mininav
 [PREVIOUS](/faq/installation/) [TOP](/faq/) [NEXT](/faq/validator/)
-:::
 
 © Copyright 2018, Intel Corporation.

--- a/faq/upgrade.md
+++ b/faq/upgrade.md
@@ -1,19 +1,19 @@
-\-\--layout: page hide: true tags: \[faq\] title: Sawtooth FAQ -
-Upgrading Hyperledger Sawtooth permalink: /faq/upgrade/ \# Copyright (c)
-2019, Intel Corporation. \# Licensed under Creative Commons Attribution
-4.0 International License \#
-<https://creativecommons.org/licenses/by/4.0/> \-\--Sawtooth FAQ:
-Upgrading Hyperledger Sawtooth
-============================================
+---
+layout: page
+hide: true
+tags: [faq]
+title: Sawtooth FAQ - Upgrading Hyperledger Sawtooth
+permalink: /faq/upgrade/
+# Copyright (c) 2019, Intel Corporation.
+# Licensed under Creative Commons Attribution 4.0 International License 
+# <https://creativecommons.org/licenses/by/4.0/>
+---
 
-::: mininav
+# Sawtooth FAQ: Upgrading Hyperledger Sawtooth
+
 [PREVIOUS](/faq/docker/) [TOP](/faq/) [NEXT](/faq/glossary/)
-:::
 
-::: contents
-:::
-
-# Points to consider while upgrading Hyperledger Sawtooth
+## Points to consider while upgrading Hyperledger Sawtooth
 
 This is applicable to upgrade from version 1.0.X to 1.1.X
 
@@ -48,19 +48,19 @@ when the upgrade happens. Client can consider this as validator service
 unavailable and retry the transactions when the validator service is up
 again.
 
-# Transaction Processor upgrades
+## Transaction Processor upgrades
 
 -   Maintain old versions of transaction processors, even though clients
     are not sending transactions to the old version. This is required so
     that when a new validator is added to the network and it needs to
     catch up with earlier published blocks.
 
-# Consensus engine upgrades
+## Consensus engine upgrades
 
 -   Maintain older version of consensus engines for a newly added node
     in the network, to catch up with the earlier blocks.
 
-# General practice for deploying a Hyperledger Sawtooth application
+## General practice for deploying a Hyperledger Sawtooth application
 
 -   Transactions may be rejected by a validator if the input rate is
     higher than what a validator can handle in its queue. The queue
@@ -69,8 +69,6 @@ again.
     should consider this queue full case at validator end and retry the
     same transaction when the validator is able to handle.
 
-::: mininav
 [PREVIOUS](/faq/docker/) [TOP](/faq/) [NEXT](/faq/glossary/)
-:::
 
 © Copyright 2018, Intel Corporation.

--- a/faq/validator.md
+++ b/faq/validator.md
@@ -1,16 +1,20 @@
-\-\--layout: page hide: true tags: \[faq\] title: Sawtooth FAQ -
-Validator permalink: /faq/validator/ \# Copyright (c) 2018, Intel
-Corporation. \# Licensed under Creative Commons Attribution 4.0
-International License \# <https://creativecommons.org/licenses/by/4.0/>
-\-\--Sawtooth FAQ: Validator ======================= .. class:: mininav
+---
+layout: default
+hide: true
+tags: [faq]
+title: Sawtooth FAQ - Validator
+permalink: /faq/validator/
+# Copyright (c) 2018, Intel Corporation.
+# Licensed under Creative Commons Attribution 4.0 International License
+# <https://creativecommons.org/licenses/by/4.0/>
+---
+
+# Sawtooth FAQ: Validator
 
 [PREVIOUS](/faq/transaction-processing/) [TOP](/faq/)
 [NEXT](/faq/consensus/)
 
-::: contents
-:::
-
-# What validation does the validator do?
+## What validation does the validator do?
 
 At a high-level, the Validator verifies the following:
 
@@ -20,13 +24,13 @@ At a high-level, the Validator verifies the following:
 -   Structure - Check structural composition of batches: duplicate
     transactions, extra transactions, etc.
 
-# Is there a simple example to show how to run Sawtooth
+## Is there a simple example to show how to run Sawtooth
 
 See these instructions to install and use Sawtooth with Docker, Ubuntu
 Linux, or AWS:
 <https://sawtooth.hyperledger.org/docs/core/nightly/master/app_developers_guide/installing_sawtooth.html>
 
-# Is there an example for a multiple node Sawtooth Network?
+## Is there an example for a multiple node Sawtooth Network?
 
 See these instructions for setting up a 5-node Sawtooth Network with
 PoET CFT Consensus using Docker:
@@ -40,17 +44,17 @@ genesis block only with the first validator. Do not create multiple
 genesis blocks with subsequent validators (that is do not re-run
 `sawset genesis` and `sawadm genesis`).
 
-# How do I add a node to a Sawtooth Network?
+## How do I add a node to a Sawtooth Network?
 
 See
 <https://sawtooth.hyperledger.org/docs/core/nightly/master/app_developers_guide/creating_sawtooth_network.html#ubuntu-add-a-node-to-the-single-node-environment>
 
-# How do I verify the Validator is running and reachable?
+## How do I verify the Validator is running and reachable?
 
 Run the following command from the Validator Docker container or from
 where the Validator is running:
 
-# What do I do if some of the Sawtooth Network nodes go offline?
+## What do I do if some of the Sawtooth Network nodes go offline?
 
 You can restart any failed nodes. They should rejoin the network and
 will then process all blocks that were added to the blockchain since the
@@ -79,7 +83,7 @@ You should see a JSON response similar to this:
               "header": {
                 "signer_public_key": . . .
 
-# Do all validators need to run the same transaction processors?
+## Do all validators need to run the same transaction processors?
 
 Yes. All validators must run all of the same transaction processors that
 are on the network. If a validator receives a transaction that it does
@@ -90,12 +94,12 @@ can also limit which transactions are accepted on the network with the
 `sawtooth.validator.transaction_families` setting. If that setting is
 not set, all transaction would be accepted.
 
-# I set sawtooth.validator.transaction_families as follows (from the documentation) but it\'s ignored
+## I set sawtooth.validator.transaction_families as follows (from the documentation) but it\'s ignored
 
 The sawtooth.validator.transaction_families setting is ignored using
 dev-mode consensus and does not need to be set.
 
-# What is the difference between `sawtooth-validator --peers {list}` and `sawtooth-validator --seeds {list}`?
+## What is the difference between `sawtooth-validator --peers {list}` and `sawtooth-validator --seeds {list}`?
 
 There are two peering modes in sawtooth: static and dynamic. The static
 peering mode requires the `--peers` arg to connect to other peer
@@ -104,14 +108,14 @@ specified will be processed and then use `--seeds` for the initial
 connection to the validator network and to start topology build-out
 (discovery and connection to more peer validators).
 
-# For static peering do I need to specify all validator nodes, or just some of them?
+## For static peering do I need to specify all validator nodes, or just some of them?
 
 For static, you need to specify all nodes. I recommend dynamic peering
 where you don\'t need to specify all of them, just a good sampling (with
 \--seeds). The rest will be discovered. All dynamic peers have to
 specified by at least one other node (and preferably multiple nodes).
 
-# What files does Sawtooth use?
+## What files does Sawtooth use?
 
 `/var/lib/sawtooth/`
 
@@ -143,14 +147,14 @@ files under your home directory, `~` ). Detailed configuration
 information and examples for Sawtooth directories is at
 `/etc/sawtooth/path.toml.example`
 
-# Why does the validator create large 1TByte files?
+## Why does the validator create large 1TByte files?
 
 The large 1TByte files in `/var/lib/sawtooth/` are \"sparse\" files,
 implemented with LMDB (Lightning Memory-mapped Database). They are
 random-access files with mostly empty blocks. They do not actually
 consume 1Tbyte of storage.
 
-# How do I backup a large sparse file?
+## How do I backup a large sparse file?
 
 One method to backup it up is to use the `tar -S` option (sparse
 option). For example: `tar cSf merkle-00.tar merkle-00.*` . Some of the
@@ -164,7 +168,7 @@ For example,
 `mdb_dump -n /var/lib/sawtooth/block-00.lmdb >block-00.lmdb.dump` Use
 `mdb_load -n -f block-00.lmdb.dump` to restore the database.
 
-# What does `lmdb.CorruptedError: mdb_put: MDB_CORRUPTED: Located page was wrong type` mean?
+## What does `lmdb.CorruptedError: mdb_put: MDB_CORRUPTED: Located page was wrong type` mean?
 
 The LMDB database, which stores the blockchain, is corrupted. The
 blockchain is backed-up automatically with multiple nodes. There are no
@@ -172,7 +176,7 @@ published recovery tools, but you could clean out the data on the failed
 machine and restart and then allow the chain to be rebuilt from its
 peers.
 
-# What TCP ports does Sawtooth use?
+## What TCP ports does Sawtooth use?
 
 -   4004 is used by the Validator component bus, which uses ZMQ. The
     validator listens to requests on this port from the REST API and
@@ -206,7 +210,7 @@ peers.
 
 Sawtooth does not use UDP ports (only TCP).
 
-# How do I create a Sawtooth Network?
+## How do I create a Sawtooth Network?
 
 See *Creating a Sawtooth Network* at
 <https://sawtooth.hyperledger.org/docs/core/nightly/master/app_developers_guide/creating_sawtooth_network.html>
@@ -214,14 +218,14 @@ See *Creating a Sawtooth Network* at
 Create the genesis block only one time, on the first node, and configure
 one or more peer Validator nodes for each node.
 
-# I have Sawtooth running with a single node. How do I add a node?
+## I have Sawtooth running with a single node. How do I add a node?
 
 You need to either start up the validator with information about the
 network peers using the `sawtooth-validator --peers` option or set
 `seeds` or `peers` in configuration file `/etc/sawtooth/validator.toml`.
 Then restart the node.
 
-# Can I run two validators on the same machine?
+## Can I run two validators on the same machine?
 
 Yes, but it is not recommended. You need to configure separate Sawtooth
 instances with different:
@@ -252,7 +256,7 @@ instances with different:
     VirtualBox) for each validator. This ensures isolation of files and
     ports for each Validator.
 
-# What TCP ports should I restrict or allow through a firewall?
+## What TCP ports should I restrict or allow through a firewall?
 
 -   TCP Port 4004 is used for internal validator / transaction processor
     communications. Restrict from outside use
@@ -261,7 +265,7 @@ instances with different:
     the host
 -   TCP Port 8080 is used to communicate between validator nodes. Allow
 
-# What is the validator parallel scheduler?
+## What is the validator parallel scheduler?
 
 The validator has two schedulers\--parallel and serial. The parallel
 scheduler gives a performance boost because it allows multiple
@@ -272,13 +276,13 @@ default is `serial` for Sawtooth 1.1 and earlier and `parallel` for the
 (unreleased) Sawtooth nightly build. For example:
 `sawtooth-validator --scheduler parallel -vv` .
 
-# What are the verbosity levels of the various Sawtooth CLIs?
+## What are the verbosity levels of the various Sawtooth CLIs?
 
 -   `-v` means warning messages
 -   `-vv` means information + warning messages
 -   `-vvv` means debug + information + warning messages
 
-# After a failed transaction, the validator stops processing further transactions. What can I do?
+## After a failed transaction, the validator stops processing further transactions. What can I do?
 
 You can run the validator in parallel processing mode. For a serial
 scheduler, a failed transaction will be retried and no further
@@ -286,7 +290,7 @@ transactions can be processed until the blocked transaction is processed
 successfully. Parallel scheduling will cause non-dependent transactions
 to be scheduled irrespective of the failed transaction.
 
-# How can I improve Sawtooth performance?
+## How can I improve Sawtooth performance?
 
 -   First, for performance measurement or tuning, do not run the default
     \"dev mode\" consensus algorithm. Run another one, such as PoET SGX
@@ -313,7 +317,7 @@ to be scheduled irrespective of the failed transaction.
 -   As you make changes, measure the impact with a performance tool such
     as Hyperledger Caliper
 
-# Is there any way to get real-time Sawtooth statistics?
+## Is there any way to get real-time Sawtooth statistics?
 
 Yes. Sawtooth has Telegraf/InfluxDB/Grafana to gather and display
 metrics. Install the packages and follow these instructions:
@@ -322,21 +326,21 @@ metrics. Install the packages and follow these instructions:
 Here is a Sawtooth Grafana screenshot:
 <https://twitter.com/liedenavilla/status/1042792583221653504>
 
-# What does this error mean: `[... DEBUG client_handlers] Unable to find entry at address ...`?
+## What does this error mean: `[... DEBUG client_handlers] Unable to find entry at address ...`?
 
 It means the address doesn\'t exist. I\'ve seen this error when
 retrieving a value that should have been written, but was not written.
 The reason was because the transaction processor for the value was not
 running so the object at the address was never created.
 
-# What does this error mean: `sawtooth-validator[... ERROR cli] Cannot have a genesis_batch_file and an existing chain`?
+## What does this error mean: `sawtooth-validator[... ERROR cli] Cannot have a genesis_batch_file and an existing chain`?
 
 You tried to create a new genesis block when you did not need to
 (because there already is a genesis block). To solve, this remove file
 `/var/lib/sawtooth/genesis.batch.file` and restart `sawtooth-validator`
 .
 
-# I get this error when testing with a lot of validators: `Max occupancy was not provided by transaction processor: ... Using default max occupancy: 10`
+## I get this error when testing with a lot of validators: `Max occupancy was not provided by transaction processor: ... Using default max occupancy: 10`
 
 You need to set the number of validators if it\'s over 10. For example,
 in `/etc/sawtooth/validator.toml` set `maximum_peer_connectivity = 50`
@@ -345,19 +349,19 @@ See
 You can also use the [sawtooth-validator
 \--maximum-peer-connectivity]{.title-ref} command line option.
 
-# I start the validator, but it\'s stuck at this message: `Waiting for transaction processor (sawtooth_settings, 1.0)`
+## I start the validator, but it\'s stuck at this message: `Waiting for transaction processor (sawtooth_settings, 1.0)`
 
 The Sawtooth Settings TP is mandatory for all Sawtooth nodes\--even if
 you don\'t add or change any settings. You probably want to also start
 the TP for your desired application. To start the Settings TP, type:
 `sudo -u sawtooth settings-tp -v`
 
-# Can I change Sawtooth settings after genesis?
+## Can I change Sawtooth settings after genesis?
 
 Yes, but you are limited to using the rule that is currently set for
 changing settings. This is handled by the Settings TP.
 
-# Why am I getting this validator message: `Reject building on block 8c5ebbea: Validator is claiming blocks too frequently.`
+## Why am I getting this validator message: `Reject building on block 8c5ebbea: Validator is claiming blocks too frequently.`
 
 It is from the z-test, which is a defense-in-depth mechanism to catch
 validators that are publishing blocks with an improbable frequency.
@@ -369,7 +373,7 @@ fix that in your test network is to restart it with some different
 z-test settings. This will effectively disable z-test:
 `sawtooth.poet.ztest_minimum_win_count = 999999999`
 
-# Why do I get a `Block validation failed` message from the validator?
+## Why do I get a `Block validation failed` message from the validator?
 
 Usually block validation fails because of something non-deterministic in
 the transaction processor. This is usually because of the serialization
@@ -377,12 +381,12 @@ method, which is usually because someone used JSON (use something like
 Protobufs or CBOR instead). Other common sources of non-determinism are
 relying on system time in the transaction processor logic.
 
-# What does this error mean: `Network communications between validators will not be authenticated or encrypted.`
+## What does this error mean: `Network communications between validators will not be authenticated or encrypted.`
 
 It means you did not configure your `network_public_key` and
 `network_private_key` in `validator.toml`.
 
-# How do I generate the `network_public_key` and `network_private_key` in `validator.toml` ?
+## How do I generate the `network_public_key` and `network_private_key` in `validator.toml` ?
 
 These are the ZMQ message keys used to securely communicate with other
 nodes.
@@ -410,7 +414,7 @@ $ ./curve_keygen
 Copy the corresponding public key output to `network_public_key` and the
 private key output to `network_private_key` fields in `validator.toml`
 
-# What does this warning mean: `Network key pair is not configured, Network communications between validators will not be authenticated or encrypted` ?
+## What does this warning mean: `Network key pair is not configured, Network communications between validators will not be authenticated or encrypted` ?
 
 You did not configure the keypair for the network nodes. For development
 purposes, that is OK. For production, use create a network keypair and
@@ -418,7 +422,7 @@ add to file [validator.toml]{.title-ref}, as instructed in the question
 here about how to generate the `network_public_key` and
 `network_private_key` .
 
-# I am seeing only one transaction per block in my blockchain. Why?
+## I am seeing only one transaction per block in my blockchain. Why?
 
 The Sawtooth Validator combines transaction batches when possible. If
 you are using dev mode consensus, it is producing blocks as fast as
@@ -429,13 +433,13 @@ include many more transactions per block. You can also combine
 transactions from your client by submitting multiple transactions in a
 batch.
 
-# What does `Block publishing suspended until new chain head arrives` mean?
+## What does `Block publishing suspended until new chain head arrives` mean?
 
 It means that a new block arrived and the receiving validator wants to
 stop creating the block it was working on until it finds the new chain
 head.
 
-# After adding 100,000 blockchain state variables, I run out of memory. Why?
+## After adding 100,000 blockchain state variables, I run out of memory. Why?
 
 Sawtooth stores the blockchain in a LMDB database at
 `/var/lib/Sawtooth/block-00.lmdb` . The LMDB database is a \"sparse\"
@@ -445,13 +449,11 @@ filesystem storage is available. The memory error could happen in
 Kubernetes or Docker or other virtual machine environments where there
 are no storage volumes mapped to the VM.
 
-# What are the maximum number of blocks in a Sawtooth blockchain?
+## What are the maximum number of blocks in a Sawtooth blockchain?
 
 There is no limit, other than the available storage for a node.
 
-::: mininav
 [PREVIOUS](/faq/transaction-processing/) [TOP](/faq/)
 [NEXT](/faq/consensus/)
-:::
 
 © Copyright 2018, Intel Corporation.

--- a/faq/videos.md
+++ b/faq/videos.md
@@ -1,18 +1,21 @@
-\-\--layout: page hide: true tags: \[appendix\] title: Appendix -
-Sawtooth Videos permalink: /faq/videos/ \# Copyright (c) 2018, Intel
-Corporation. \# Licensed under Creative Commons Attribution 4.0
-International License \# <https://creativecommons.org/licenses/by/4.0/>
-\-\--FAQ Appendix: Sawtooth Videos ============================= ..
-class:: mininav
+---
+layout: default
+hide: true
+tags: [appendix]
+title: Appendix - Sawtooth Videos
+permalink: /faq/videos/
+# Copyright (c) 2018, Intel Corporation.
+# Licensed under Creative Commons Attribution 4.0 International License
+# <https://creativecommons.org/licenses/by/4.0/>
+---
+
+# FAQ Appendix: Sawtooth Videos
 
 [PREVIOUS](/faq/settings/) [TOP](/faq/)
 
-::: contents
-:::
-
 # Selected YouTube Videos
 
-# 2019 YouTube Videos
+## 2019 YouTube Videos
 
 Hyperledger Sawtooth Application Development Overview using \"SimpleWallet\" (57:18, Dan Anderson, Intel, 2019)
 
@@ -22,7 +25,7 @@ Hyperledger Sawtooth Performance Metrics with Grafana (28:00, Dan Anderson, Inte
 
 :   <https://youtu.be/YBd7PJlNRSQ>
 
-# 2018 YouTube Videos
+## 2018 YouTube Videos
 
 Hyperledger Sawtooth Release 1.1 (34:28, Dan Anderson, Intel, 2018)
 
@@ -77,7 +80,7 @@ Introducción a Hyperledger VII - Sawtooth (Español) (7:36, Sergio Torres, Bloc
 
 :   <https://youtu.be/_YkKaDXLVPg>
 
-# 2017 YouTube Videos
+## 2017 YouTube Videos
 
 Vision for Hyperledger\'s Sawtooth Distributed Ledger (2:03, Dan Middleton, Intel, 2017)
 
@@ -87,13 +90,13 @@ Introduction to Hyperledger Sawtooth (Seafood Supply Chain) (3:40, Hyperledger, 
 
 :   <https://youtu.be/8nrVlICgiYM>
 
-# Hyperledger Videos
+## Hyperledger Videos
 
 Hyperledger Sawtooth 1.0: Market Significance and Technical Overview. Free registration required (61:27, Dan Middleton, Intel, 2018)
 
 :   <https://gateway.on24.com/wcc/gateway/linux/1101876/1585244/hyperledger-sawtooth-v10-market-significance-and-technical-overview>
 
-# Intel Chip Chat Audio
+## Intel Chip Chat Audio
 
 Revolutionizing Identity Management with \[Sawtooth\] Blockchain. Ep. 612 (8:33, Chris Spanton, T-Mobile, 2018)
 
@@ -107,13 +110,13 @@ Where We\'ve Been and Where We\'re going \-- Intel\'s Blockchain Journey. Ep. 55
 
 :   <https://connectedsocialmedia.com/16112/where-weve-been-and-where-were-going-intels-blockchain-journey-intel-chip-chat-episode-559/>
 
-# Sawtooth Technical Forum
+## Sawtooth Technical Forum
 
 This is an list of recordings of past Hyperledger Sawtooth Technical
 Forums. Most are in mp4 (video) format, but a few are available in audio
 only (m4a).
 
-# 2018 Sawtooth Technical Forum
+## 2018 Sawtooth Technical Forum
 
 Located at
 <https://drive.google.com/drive/folders/0B_NJV6eJXAA1VnFUakRzaG1raXc>
@@ -174,7 +177,7 @@ Sawtooth Rust SDK (Peter Schwarz, Bitwise)
 :   [20180215-sawtooth-tech-forum.m4a](https://drive.google.com/file/d/1Lr2Ik3HjFU5tODce2chED5oR3Vhci6-G/view)
     (audio only; starts at 23:40)
 
-# 2017 Sawtooth Technical Forum
+## 2017 Sawtooth Technical Forum
 
 Located at
 <https://drive.google.com/drive/folders/12HLBKfFEF09eKhjqkvtTStejx4ZD8btW>
@@ -239,8 +242,6 @@ PoET Consensus on Sawtooth Lake (Jamie Jason, Intel)
 :   [20170622-sawtooth-tech-forum.mp4](https://drive.google.com/file/d/0B_NJV6eJXAA1TGdfMjJlT0Qtb0U/view)
     (starts at 12:00)
 
-::: mininav
 [PREVIOUS](/faq/settings/) [TOP](/faq/)
-:::
 
 © Copyright 2018, Intel Corporation.


### PR DESCRIPTION
There are five main things this pr does

   1. Fix the header/title format to be actual markdown
   2. Remove contents tags
   3. Remove mininav tags
    4. Change subheadings from # to ## to make them less bold than the titles
    5. Change layout variable value from page to default

One commit also has a large change to update a table into markdown format.
