### PR TITLE
Correct configure_sgx markdown

### DIFF
--- a/_includes/1.2/left_sidebar.html
+++ b/_includes/1.2/left_sidebar.html
@@ -69,7 +69,7 @@
     <div class="left-sidebar-group">
         <div class="left-sidebar-header">System Administrator's Guide</div>
         <a href="{% link docs/1.2/sysadmin_guide/setting_up_sawtooth_network.md %}">Setting Up a Sawtooth Network</a>
-        <a href="{% link docs/1.2/index.md %}">Using Sawtooth with PoET-SGX</a>
+        <a href="{% link docs/1.2/sysadmin_guide/configure_sgx.md %}">Using Sawtooth with PoET-SGX</a>
         <a href="{% link docs/1.2/index.md %}">Setting the Allowed Transaction Types (Optional)</a>
         <a href="{% link docs/1.2/index.md %}">Adding Authorized Users for Settings Proposals</a>
         <a href="{% link docs/1.2/index.md %}">Using Proxy Server to Authorize the REST API</a>

--- a/docs/1.2/sysadmin_guide/configure_sgx.md
+++ b/docs/1.2/sysadmin_guide/configure_sgx.md
@@ -1,15 +1,9 @@
----
-title: Using Sawtooth with PoET-SGX
----
+# Using Sawtooth with PoET-SGX
 
-::: note
-::: title
-Note
-:::
-
-PoET-SGX is currently not compatible with Sawtooth 1.1 or later. Users
-looking to leverage PoET-SGX should remain on Sawtooth 1.0.
-:::
+> **Note**
+>
+> PoET-SGX is currently not compatible with Sawtooth 1.1 or later. Users
+> looking to leverage PoET-SGX should remain on Sawtooth 1.0.
 
 This procedure describes how to install, configure, and run Hyperledger
 Sawtooth with PoET simulator consensus on a system with Intel ® Software
@@ -17,38 +11,31 @@ Guard Extensions (SGX).
 
 For the procedure to configure a Sawtooth node with a different
 consensus algorithm, such as PoET, see
-`setting_up_sawtooth_network`{.interpreted-text role="doc"}.
+[Setting Up a Sawtooth Network]({% link
+docs/1.2/sysadmin_guide/setting_up_sawtooth_network.md %}).
 
-::: note
-::: title
-Note
-:::
+> **Note**
+>
+> These instructions have been tested with Sawtooth 1.0 on Ubuntu 16.04
+> only.
 
-These instructions have been tested with Sawtooth 1.0 on Ubuntu 16.04
-only.
-:::
-
-# Prerequisites
+## Prerequisites
 
 <!--
   Licensed under Creative Commons Attribution 4.0 International License
   https://creativecommons.org/licenses/by/4.0/
 -->
 
-## BIOS Update
+### BIOS Update
 
-::: important
-::: title
-Important
-:::
-
-You may need to update your BIOS with a security fix before running
-Hyperledger Sawtooth with PoET. Affected versions and instructions for
-updating can be found on [Intel\'s
-website](https://security-center.intel.com/advisory.aspx?intelid=INTEL-SA-00076&languageid=en-fr).
-If you\'re running an affected version, you must update the BIOS to
-ensure that these installation instructions work correctly.
-:::
+> **Important**
+>
+> You may need to update your BIOS with a security fix before running
+> Hyperledger Sawtooth with PoET. Affected versions and instructions for
+> updating can be found on [Intel\'s
+> website](https://security-center.intel.com/advisory.aspx?intelid=INTEL-SA-00076&languageid=en-fr).
+> If you\'re running an affected version, you must update the BIOS to
+> ensure that these installation instructions work correctly.
 
 You can verify the BIOS version after the machine has booted by running:
 
@@ -62,7 +49,7 @@ $ sudo lshw| grep -A5 *-firmware
           date: 08/16/2017
 ```
 
-# Install SGX and PSW {#install-sgx}
+## Install SGX and PSW {#install-sgx}
 
 Install the prerequisites for SGX and the Intel SGX Platform Software
 (PSW).
@@ -152,34 +139,25 @@ $ sudo ./sgx_linux_ubuntu16.04.1_x64_psw_2.0.100.40950.bin
 After ensuring that the SGX kernel module is loaded, go to the next
 section to install and configure Sawtooth.
 
-# Configuring Sawtooth to Use PoET-SGX
+## Configuring Sawtooth to Use PoET-SGX
 
 This section describes the Sawtooth steps to configure PoET-SGX
 consensus.
 
-## Install Sawtooth
+### Install Sawtooth
 
 ``` console
 $ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 8AA7AF1F1091A5FD
+$ sudo add-apt-repository 'deb [arch=amd64] <http://repo.sawtooth.me/ubuntu/chime/stable> bionic universe'
+$ sudo apt-get update
+$ sudo apt-get install -y \
+    sawtooth \
+    python3-sawtooth-poet-engine \
+    python3-sawtooth-poet-families \
+    python3-sawtooth-poet-sgx
 ```
 
-\<\<\<\<\<\<\< HEAD:docs/core/1.0/sysadmin_guide/configure_sgx.rst
-
-:   \$ sudo add-apt-repository \'deb
-    <http://repo.sawtooth.me/ubuntu/1.0/stable> xenial universe\'
-
-=======
-
-:   \$ sudo add-apt-repository \'deb \[arch=amd64\]
-    <http://repo.sawtooth.me/ubuntu/chime/stable> bionic universe\'
-
-\>\>\>\>\>\>\> core/1-2:docs/core/1.2/sysadmin_guide/configure_sgx.rst
-
-:   \$ sudo apt-get update \$ sudo apt-get install -y sawtooth
-    python3-sawtooth-poet-engine python3-sawtooth-poet-families
-    python3-sawtooth-poet-sgx
-
-## Certificate File
+### Certificate File
 
 The configuration process requires an SGX certificate file in PEM format
 (.pem), which you will need before continuing.
@@ -193,7 +171,7 @@ attestation service. [Click
 here](https://software.intel.com/formfill/sgx-onboarding) for the
 registration form.
 
-## Configure the Validator for PoET-SGX {#config-validator-for-PoET-SGX-label}
+### Configure the Validator for PoET-SGX {#config-validator-for-PoET-SGX-label}
 
 After installing Sawtooth, add config settings so PoET-SGX will work
 properly.
@@ -239,16 +217,12 @@ Create validator keys:
 $ sudo sawadm keygen
 ```
 
-::: note
-::: title
-Note
-:::
-
-If you\'re configuring multiple Sawtooth nodes, the following steps are
-required for the first node only. For the other nodes, you can skip the
-rest of this procedure; continue with `val-config`{.interpreted-text
-role="ref"}.
-:::
+> **Note**
+>
+> If you\'re configuring multiple Sawtooth nodes, the following steps are
+> required for the first node only. For the other nodes, you can skip the
+> rest of this procedure; continue with [Change the Validator Config
+> File](#val-config).
 
 Become the `sawtooth` user and change to `/tmp`. In the following
 commands, the prompt `[sawtooth@system]` shows the commands that must be
@@ -286,47 +260,36 @@ output showing that the SGX enclave has been initialized:
 [12:03:59 WARNING poet_enclave] SGX PoET enclave initialized.
 ```
 
-::: note
-::: title
-Note
-:::
-
-There's quite a bit going on in the previous `sawset proposal` command,
-so let's take a closer look at what it accomplishes:
-
-`sawtooth.consensus.algorithm.name=PoET`
-
-:   Changes the consensus algorithm to PoET.
-
-`sawtooth.consensus.algorithm.version=0.1`
-
-:   Changes the version of the consensus algorithm to 0.1.
-
-`sawtooth.poet.report_public_key_pem="$(cat /etc/sawtooth/ias_rk_pub.pem)"`
-
-:   Adds the public key that the PoET Validator Registry transaction
-    processor uses to verify attestation reports.
-
-`sawtooth.poet.valid_enclave_measurements=$(poet enclave --enclave-module sgx measurement)`
-
-:   Adds the enclave measurement for your enclave to the blockchain for
-    the PoET Validator Registry transaction processor to use to check
-    signup information.
-
-`sawtooth.poet.valid_enclave_basenames=$(poet enclave --enclave-module sgx basename)`
-
-:   Adds the enclave basename for your enclave to the blockchain for the
-    PoET Validator Registry transaction processor to use to check signup
-    information.
-
-`sawtooth.poet.enclave_module_name`
-
-:   Specifies the name of the Python module that implements the PoET
-    enclave. In this case,
-    `sawtooth_poet_sgx.poet_enclave_sgx.poet_enclave` is the SGX version
-    of the enclave; it includes the Python code as well as the Python
-    extension.
-:::
+> **Note**
+>
+> There's quite a bit going on in the previous `sawset proposal` command,
+> so let's take a closer look at what it accomplishes:
+>
+> `sawtooth.consensus.algorithm.name=PoET`
+> :   Changes the consensus algorithm to PoET.
+>
+> `sawtooth.consensus.algorithm.version=0.1`
+>  :   Changes the version of the consensus algorithm to 0.1.
+>
+> `sawtooth.poet.report_public_key_pem="$(cat /etc/sawtooth/ias_rk_pub.pem)"`
+>  :   Adds the public key that the PoET Validator Registry transaction
+>      processor uses to verify attestation reports.
+> `sawtooth.poet.valid_enclave_measurements=$(poet enclave --enclave-module sgx measurement)`
+> :   Adds the enclave measurement for your enclave to the blockchain for
+>     the PoET Validator Registry transaction processor to use to check
+>     signup information.
+>
+> `sawtooth.poet.valid_enclave_basenames=$(poet enclave --enclave-module sgx basename)`
+> :   Adds the enclave basename for your enclave to the blockchain for the
+>     PoET Validator Registry transaction processor to use to check signup
+>     information.
+>
+> `sawtooth.poet.enclave_module_name`
+> :   Specifies the name of the Python module that implements the PoET
+>     enclave. In this case,
+>     `sawtooth_poet_sgx.poet_enclave_sgx.poet_enclave` is the SGX version
+>     of the enclave; it includes the Python code as well as the Python
+>     extension.
 
 Create a poet-genesis batch:
 
@@ -359,7 +322,7 @@ Genesis configuration is complete! Log out of the sawtooth account:
 $
 ```
 
-## Change the Validator Config File {#val-config}
+### Change the Validator Config File {#val-config}
 
 You must specify some networking information so that the validator
 advertises itself properly and knows where to search for peers. Create
@@ -453,27 +416,23 @@ The default network bind interface is \"eno1\". If this device doesn\'t
 exist on your machine, change the `network` definition to specify the
 correct bind interface.
 
-::: tip
-::: title
-Tip
-:::
-
-Make sure that all values in this setting are valid for your network. If
-the bind interface doesn\'t exist, you may see a ZMQ error in the
-sawtooth-validator systemd logs when attempting to start the validator,
-as in this example:
-
-``` console
-Jun 02 14:50:37 ubuntu validator[15461]:   File "/usr/lib/python3.5/threading.py", line 862, in run
-...
-Jun 02 14:50:37 ubuntu validator[15461]:   File "zmq/backend/cython/socket.pyx", line 487, in zmq.backend.cython.socket.Socket.bind (zmq/backend/cython/socket.c:5156)
-Jun 02 14:50:37 ubuntu validator[15461]:   File "zmq/backend/cython/checkrc.pxd", line 25, in zmq.backend.cython.checkrc._check_rc (zmq/backend/cython/socket.c:7535)
-Jun 02 14:50:37 ubuntu validator[15461]: zmq.error.ZMQError: No such device
-Jun 02 14:50:37 ubuntu systemd[1]: sawtooth-validator.service: Main process exited, code=exited, status=1/FAILURE
-Jun 02 14:50:37 ubuntu systemd[1]: sawtooth-validator.service: Unit entered failed state.
-Jun 02 14:50:37 ubuntu systemd[1]: sawtooth-validator.service: Failed with result 'exit-code'.
-```
-:::
+> **Tip**
+>
+> Make sure that all values in this setting are valid for your network. If
+> the bind interface doesn\'t exist, you may see a ZMQ error in the
+> sawtooth-validator systemd logs when attempting to start the validator,
+> as in this example:
+>
+> ``` console
+> Jun 02 14:50:37 ubuntu validator[15461]:   File "/usr/lib/python3.5/threading.py", line 862, in run
+> ...
+> Jun 02 14:50:37 ubuntu validator[15461]:   File "zmq/backend/cython/socket.pyx", line 487, in zmq.backend.cython.socket.Socket.bind (zmq/backend/cython/socket.c:5156)
+> Jun 02 14:50:37 ubuntu validator[15461]:   File "zmq/backend/cython/checkrc.pxd", line 25, in zmq.backend.cython.checkrc._check_rc (zmq/backend/cython/socket.c:7535)
+> Jun 02 14:50:37 ubuntu validator[15461]: zmq.error.ZMQError: No such device
+> Jun 02 14:50:37 ubuntu systemd[1]: sawtooth-validator.service: Main process exited, code=exited, status=1/FAILURE
+> Jun 02 14:50:37 ubuntu systemd[1]: sawtooth-validator.service: Unit entered failed state.
+> Jun 02 14:50:37 ubuntu systemd[1]: sawtooth-validator.service: Failed with result 'exit-code'.
+> ```
 
 (Optional) Change the network keys to specify secured network
 communication between nodes in the network. By default, the network is
@@ -486,35 +445,35 @@ participating nodes.
 
 Next, generate your network keys.
 
-> -   This example shows how to use Python to generate these keys:
->
->     ``` python
->     python
->      ...
->     >>> import zmq
->     >>> (public, secret) = zmq.curve_keypair()
->     >>> print public
->     wFMwoOt>yFqI/ek.G[tfMMILHWw#vXB[Sv}>l>i)
->     >>> print secret
->     r&oJ5aQDj4+V]p2:Lz70Eu0x#m%IwzBdP(}&hWM*
->     ```
->
-> -   Or you could use the following steps to compile and run
->     `curve_keygen` to generate the keys:
->
->     ``` console
->     $ sudo apt-get install g++ libzmq3-dev
->       ...
->     $ wget https://raw.githubusercontent.com/zeromq/libzmq/master/tools/curve_keygen.cpp
->      ...
->     $ g++ curve_keygen.cpp -o curve_keygen -lzmq
->
->     $./curve_keygen
->     == CURVE PUBLIC KEY ==
->     -so<iWpS=5uINn*eV$=J)F%lEFd=@g:g@GqmL2C]
->     == CURVE SECRET KEY ==
->     G1.mNaJLnJxb6BWsY=P[K3D({+uww!T&LC3(Xq:B
->     ```
+- This example shows how to use Python to generate these keys:
+
+  ``` python
+  python
+   ...
+  >>> import zmq
+  >>> (public, secret) = zmq.curve_keypair()
+  >>> print public
+  wFMwoOt>yFqI/ek.G[tfMMILHWw#vXB[Sv}>l>i)
+  >>> print secret
+  r&oJ5aQDj4+V]p2:Lz70Eu0x#m%IwzBdP(}&hWM*
+  ```
+
+- Or you could use the following steps to compile and run
+  `curve_keygen` to generate the keys:
+
+  ``` console
+  $ sudo apt-get install g++ libzmq3-dev
+    ...
+  $ wget https://raw.githubusercontent.com/zeromq/libzmq/master/tools/curve_keygen.cpp
+   ...
+  $ g++ curve_keygen.cpp -o curve_keygen -lzmq
+
+  $./curve_keygen
+  == CURVE PUBLIC KEY ==
+  -so<iWpS=5uINn*eV$=J)F%lEFd=@g:g@GqmL2C]
+  == CURVE SECRET KEY ==
+  G1.mNaJLnJxb6BWsY=P[K3D({+uww!T&LC3(Xq:B
+  ```
 
 Finally, replace the example values in the validator config file with
 your unique network keys.
@@ -532,7 +491,7 @@ $ sudo chown root:sawtooth /etc/sawtooth/validator.toml
 $ sudo chmod 640 /etc/sawtooth/validator.toml
 ```
 
-## Change the REST API Config File {#rest-api-config}
+### Change the REST API Config File {#rest-api-config}
 
 Create the REST API configuration file, `/etc/sawtooth/rest_api.toml` by
 copying the example file from `/etc/sawtooth/rest_api.toml.example`.
@@ -563,16 +522,13 @@ remove the `#` comment character to activate this setting.
 connect = "tcp://localhost:4004"
 ```
 
-::: note
-::: title
-Note
-:::
+> **Note**
+>
+> To learn how to put the REST API behind a proxy server, see
+> [Using a Proxy Server to Authorize the REST
+> API]({% link docs/1.2/sysadmin_guide/rest_auth_proxy.md %})
 
-To learn how to put the REST API behind a proxy server, see
-`rest_auth_proxy`{.interpreted-text role="doc"}.
-:::
-
-## Start the Sawtooth Services
+### Start the Sawtooth Services
 
 Use these commands to start the Sawtooth services:
 
@@ -600,7 +556,8 @@ $ sudo journalctl -f \
 ```
 
 Additional logging output can be found in `/var/log/sawtooth/`. For more
-information, see `log_configuration`{.interpreted-text role="doc"}.
+information, see [Log Configuration File]({% link
+docs/1.2/sysadmin_guide/log_configuration.md %}).
 
 To verify that the services are running:
 
@@ -614,7 +571,7 @@ $ sudo systemctl status sawtooth-intkey-tp-python.service
 $ sudo systemctl status sawtooth-identity-tp.service
 ```
 
-## Stop or Restart the Sawtooth Services
+### Stop or Restart the Sawtooth Services
 
 If you need to stop or restart the Sawtooth services for any reason, use
 the following commands:


### PR DESCRIPTION
This change corrects the markdown for the "Using Sawtooth with PoET-SGX" sysadmin guide.

It also corrects a block that contained an accidentally-committed merge conflict.
