### PR TITLE
Remove SysAdmin-PoET SGX from 1.2 sidebar

### DIFF
--- a/_includes/1.2/left_sidebar.html
+++ b/_includes/1.2/left_sidebar.html
@@ -69,7 +69,6 @@
     <div class="left-sidebar-group">
         <div class="left-sidebar-header">System Administrator's Guide</div>
         <a href="{% link docs/1.2/sysadmin_guide/setting_up_sawtooth_network.md %}">Setting Up a Sawtooth Network</a>
-        <a href="{% link docs/1.2/sysadmin_guide/configure_sgx.md %}">Using Sawtooth with PoET-SGX</a>
         <a href="{% link docs/1.2/index.md %}">Setting the Allowed Transaction Types (Optional)</a>
         <a href="{% link docs/1.2/index.md %}">Adding Authorized Users for Settings Proposals</a>
         <a href="{% link docs/1.2/index.md %}">Using Proxy Server to Authorize the REST API</a>


### PR DESCRIPTION
This doc is no longer applicable, so this change removes it from the sidebar.  The content will remain, in case another user or maintainer would like to correct it for current usage.
