### PR TITLE
1.2 Update adding_authorized_users markdown

### DIFF
--- a/_includes/1.2/left_sidebar.html
+++ b/_includes/1.2/left_sidebar.html
@@ -71,7 +71,7 @@
         <a href="{% link docs/1.2/sysadmin_guide/setting_up_sawtooth_network.md %}">Setting Up a Sawtooth Network</a>
         <a href="{% link docs/1.2/sysadmin_guide/configure_sgx.md %}">Using Sawtooth with PoET-SGX</a>
         <a href="{% link docs/1.2/index.md %}">Setting the Allowed Transaction Types (Optional)</a>
-        <a href="{% link docs/1.2/index.md %}">Adding Authorized Users for Settings Proposals</a>
+        <a href="{% link docs/1.2/sysadmin_guide/adding_authorized_users.md %}">Adding Authorized Users for Settings Proposals</a>
         <a href="{% link docs/1.2/index.md %}">Using Proxy Server to Authorize the REST API</a>
         <a href="{% link docs/1.2/index.md %}">Configuring Validator and Transactor Permissions</a>
         <a href="{% link docs/1.2/index.md %}">Using Grafana to Display Sawtooth Metrics</a>

--- a/docs/1.2/sysadmin_guide/adding_authorized_users.md
+++ b/docs/1.2/sysadmin_guide/adding_authorized_users.md
@@ -1,6 +1,4 @@
----
-title: Adding Authorized Users for Settings Proposals
----
+# Adding Authorized Users for Settings Proposals
 
 Sawtooth supports on-chain settings to configure validator behavior,
 consensus, permissions, and more. The Settings transaction processor (or
@@ -24,77 +22,68 @@ can be made.
 This procedure describes how to add a user key to
 `sawtooth.settings.vote.authorized_keys`.
 
-1.  Log into the Sawtooth node that has your private key file.
+1. Log into the Sawtooth node that has your private key file.
 
-    ::: important
-    ::: title
-    Important
-    :::
+   > **Important**
+   >
+   > If the genesis block was created with the first validator\'s key,
+   > and no user keys are authorized to change settings, you **must** run
+   > this procedure on the same node that created the genesis block. The
+   > `sawset proposal create` command requires the private validator key
+   > that was generated on that node.
 
-    If the genesis block was created with the first validator\'s key,
-    and no user keys are authorized to change settings, you **must** run
-    this procedure on the same node that created the genesis block. The
-    `sawset proposal create` command requires the private validator key
-    that was generated on that node.
-    :::
+2. Make sure that the Settings transaction processor (or an equivalent)
+   and the REST API are running, as described in [Running Sawtooth as a
+   Service]({% link docs/1.2/sysadmin_guide/setting_up_sawtooth_network.md %}#running-sawtooth-as-a-service).
 
-2.  Make sure that the Settings transaction processor (or an equivalent)
-    and the REST API are running, as described in
-    `systemd`{.interpreted-text role="doc"}.
+3. Display the existing setting.
 
-3.  Display the existing setting.
+   ```console
+   $ sawtooth settings list sawtooth.settings.vote.authorized_keys
+   ```
 
-    ``` console
-    $ sawtooth settings list sawtooth.settings.vote.authorized_keys
-    ```
+   The output will resemble this example:
 
-    The output will resemble this example:
+   ```console
+   sawtooth.settings.vote.authorized_keys: 0276023d4f7323103db8d8683a4b7bc1eae1f66...
+   ```
 
-    ``` console
-    sawtooth.settings.vote.authorized_keys: 0276023d4f7323103db8d8683a4b7bc1eae1f66...
-    ```
+   If you want to add a key to the existing list, copy the key strings
+   for the next step.
 
-    If you want to add a key to the existing list, copy the key strings
-    for the next step.
+4. Add the new user\'s public key to the list of those allowed to
+   change settings.
 
-4.  Add the new user\'s public key to the list of those allowed to
-    change settings.
+   ```console
+   $ sawset proposal create --key {PRIVATE-KEY} \
+   sawtooth.settings.vote.authorized_keys='{OLDLIST},{NEWKEY}'
+   ```
 
-    ``` none
-    $ sawset proposal create --key {PRIVATE-KEY} \
-    sawtooth.settings.vote.authorized_keys='{OLDLIST},{NEWKEY}'
-    ```
+   > **Note**
+   >
+   > -   For `{PRIVATE-KEY}`, specify the path to your private key file
+   >     (or the validator\'s private key file, if it was used to create
+   >     the genesis block).
+   > -   For `{OLDLIST}`, use the list of existing keys from step 2. To
+   >     delete a key, omit it from this list.
+   > -   For `{NEWKEY}`, use the public key of the user you want to add.
 
-    ::: note
-    ::: title
-    Note
-    :::
+5. To see the changed setting, run `sawtooth settings list` again.
 
-    -   For `{PRIVATE-KEY}`, specify the path to your private key file
-        (or the validator\'s private key file, if it was used to create
-        the genesis block).
-    -   For `{OLDLIST}`, use the list of existing keys from step 2. To
-        delete a key, omit it from this list.
-    -   For `{NEWKEY}`, use the public key of the user you want to add.
-    :::
+   ``` console
+   $ sawtooth settings list sawtooth.settings.vote.authorized_keys
+   ```
 
-5.  To see the changed setting, run `sawtooth settings list` again.
+   Check that the new user key appears on the list.
 
-    ``` console
-    $ sawtooth settings list sawtooth.settings.vote.authorized_keys
-    ```
-
-    Check that the new user key appears on the list.
-
-**About proposal voting**
+## About proposal voting
 
 Each settings change must receive a certain amount of votes in order to
 be accepted. By default, only one vote is required, and the settings
 proposal contains an automatic \"yes\" vote from the user (or validator)
 who submitted the proposal. For information on configuring more complex
 voting schemes, see
-`/transaction_family_specifications/settings_transaction_family`{.interpreted-text
-role="doc"}.
+[Settings Transaction Family]({% link docs/1.2/transaction_family_specifications/settings_transaction_family.md %})`.
 
 <!--
   Licensed under Creative Commons Attribution 4.0 International License


### PR DESCRIPTION
This change updates the markdown for the "Adding Authorized Users for Settings Proposals" guide. It also adds the link to the sidebar for the guide.
