### PR TITLE
Add conversion status information for v1.0, v1.1, and v1.2 docs.

### DIFF
--- a/_includes/1.0/left_sidebar.html
+++ b/_includes/1.0/left_sidebar.html
@@ -17,3 +17,9 @@
         <a class="dropdown-item" href="{% link docs/1.0/index.md %}">v1.0</a>
     </div>
 </div>
+<div id="left-sidebar-links" class="collapse">
+    <div class="left-sidebar-group">
+        <div class="left-sidebar-header">Site Conversion</div>
+        <a href="{% link docs/1.0/index.md %}">Status</a>
+    </div>
+</div>

--- a/_includes/1.1/left_sidebar.html
+++ b/_includes/1.1/left_sidebar.html
@@ -35,4 +35,8 @@
         <a href="{% link docs/1.1/app_developers_guide/namespace_restriction.md %}">Namespace Restriction</a>
         <a href="{% link docs/1.1/app_developers_guide/event_subscriptions.md %}">Subscribing to Events</a>
     </div>
+    <div class="left-sidebar-group">
+        <div class="left-sidebar-header">Conversion</div>
+        <a href="{% link docs/1.1/conversion_status.md %}">Status</a>
+    </div>
 </div>

--- a/_includes/1.2/left_sidebar.html
+++ b/_includes/1.2/left_sidebar.html
@@ -129,4 +129,8 @@
         <a href="{% link docs/1.2/index.md %}">Seth Transaction Family Specification</a>
         <a href="{% link docs/1.2/index.md %}">CLI Reference</a>
     </div>
+    <div class="left-sidebar-group">
+        <div class="left-sidebar-header">Conversion</div>
+        <a href="{% link docs/1.2/conversion_status.md %}">Status</a>
+    </div>
 </div>

--- a/docs/1.0/conversion_status.md
+++ b/docs/1.0/conversion_status.md
@@ -1,0 +1,37 @@
+# Conversion Status
+
+<!--
+  Copyright 2022 Cargill Incorporated
+
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+This site is undergoing a transition!
+
+Sawtooth 1.0 documentation has not yet been converted to the new site's format.
+You can find the documentation in sphinx-doc rst format at:
+
+- <https://github.com/hyperledger/sawtooth-core/tree/1-0/docs>
+
+If you wish to help contribute to the Sawtooth documentation conversion
+project, please take a few pages and convert them from sphinx-doc to Jekyll.
+A partial conversion has been done with pandoc here, and should be used as
+a starting point:
+
+- <https://github.com/hyperledger/sawtooth-docs/tree/refresh/docs/core/1.0>
+
+And the next step is to review/fix the pages and integrate them into the new
+1.0 documentation here:
+
+- <https://github.com/hyperledger/sawtooth-docs/tree/refresh/docs/1.0>
+
+A typical page conversion PR consists of the following steps:
+
+- Commit 1: Move the file into the final location
+- Commit 2: Update the file's markup (link syntax, note syntax, etc.) to work with Jekyll
+- Commit 3: Link to the file in the sidebar by updating
+  [_includes/1.0/left_sidebar.html](https://github.com/hyperledger/sawtooth-docs/blob/refresh/_includes/1.0/left_sidebar.html)
+
+When submitting PRs, please keep file moves, content conversion, and content
+changes as separate commits for easier review. Thanks!

--- a/docs/1.0/index.md
+++ b/docs/1.0/index.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /docs/1.0/conversion_status.md
+---

--- a/docs/1.1/conversion_status.md
+++ b/docs/1.1/conversion_status.md
@@ -1,0 +1,37 @@
+# Conversion Status
+
+<!--
+  Copyright 2022 Cargill Incorporated
+
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+This site is undergoing a transition!
+
+Sawtooth 1.1 documentation has not yet been completely converted to the new
+site's format.  You can find the documentation in sphinx-doc rst format at:
+
+- <https://github.com/hyperledger/sawtooth-core/tree/1-1/docs>
+
+If you wish to help contribute to the Sawtooth documentation conversion
+project, please take a few pages and convert them from sphinx-doc to Jekyll.
+A partial conversion has been done with pandoc here, and should be used as
+a starting point:
+
+- <https://github.com/hyperledger/sawtooth-docs/tree/refresh/docs/core/1.1>
+
+And the next step is to review/fix the pages and integrate them into the new
+1.1 documentation here:
+
+- <https://github.com/hyperledger/sawtooth-docs/tree/refresh/docs/1.1>
+
+A typical page conversion PR consists of the following steps:
+
+- Commit 1: Move the file into the final location
+- Commit 2: Update the file's markup (link syntax, note syntax, etc.) to work with Jekyll
+- Commit 3: Link to the file in the sidebar by updating
+  [_includes/1.1/left_sidebar.html](https://github.com/hyperledger/sawtooth-docs/blob/refresh/_includes/1.1/left_sidebar.html)
+
+When submitting PRs, please keep file moves, content conversion, and content
+changes as separate commits for easier review. Thanks!

--- a/docs/1.1/index.md
+++ b/docs/1.1/index.md
@@ -1,5 +1,10 @@
 # Introduction
 
+> **Note**
+>
+> Sawtooth v1.1 documentation has not been fully converted. For more
+> information, see the [conversion status]({% link docs/1.1/conversion_status.md %}).
+
 Hyperledger Sawtooth is an enterprise blockchain platform for building
 distributed ledger applications and networks. The design philosophy
 targets keeping ledgers *distributed* and making smart contracts *safe*,

--- a/docs/1.2/conversion_status.md
+++ b/docs/1.2/conversion_status.md
@@ -1,0 +1,37 @@
+# Conversion Status
+
+<!--
+  Copyright 2022 Cargill Incorporated
+
+  Licensed under Creative Commons Attribution 4.0 International License
+  https://creativecommons.org/licenses/by/4.0/
+-->
+
+This site is undergoing a transition!
+
+Sawtooth 1.2 documentation has not yet been completely converted to the new
+site's format.  You can find the documentation in sphinx-doc rst format at:
+
+- <https://github.com/hyperledger/sawtooth-core/tree/1-2/docs>
+
+If you wish to help contribute to the Sawtooth documentation conversion
+project, please take a few pages and convert them from sphinx-doc to Jekyll.
+A partial conversion has been done with pandoc here, and should be used as
+a starting point:
+
+- <https://github.com/hyperledger/sawtooth-docs/tree/refresh/docs/core/1.2>
+
+And the next step is to review/fix the pages and integrate them into the new
+1.1 documentation here:
+
+- <https://github.com/hyperledger/sawtooth-docs/tree/refresh/docs/1.2>
+
+A typical page conversion PR consists of the following steps:
+
+- Commit 1: Move the file into the final location
+- Commit 2: Update the file's markup (link syntax, note syntax, etc.) to work with Jekyll
+- Commit 3: Link to the file in the sidebar by updating
+  [_includes/1.2/left_sidebar.html](https://github.com/hyperledger/sawtooth-docs/blob/refresh/_includes/1.2/left_sidebar.html)
+
+When submitting PRs, please keep file moves, content conversion, and content
+changes as separate commits for easier review. Thanks!

--- a/docs/1.2/index.md
+++ b/docs/1.2/index.md
@@ -1,5 +1,10 @@
 # Introduction
 
+> **Note**
+>
+> Sawtooth v1.2 documentation has not been fully converted. For more
+> information, see the [conversion status]({% link docs/1.2/conversion_status.md %}).
+
 Hyperledger Sawtooth is an enterprise blockchain platform for building
 distributed ledger applications and networks. The design philosophy
 targets keeping ledgers *distributed* and making smart contracts *safe*,


### PR DESCRIPTION
These pages are intended to do two things:

1) Make it clear that some documentation exists that isn't on the site.
2) Provide a request to the community to help convert the remaining
   documentation.

Signed-off-by: Shawn T. Amundson <amundson@bitwise.io>