### PR TITLE
Replace easy interpreted-text ref with markdown link

### DIFF
--- a/docs/core/1.0/app_developers_guide/event_subscriptions.md
+++ b/docs/core/1.0/app_developers_guide/event_subscriptions.md
@@ -84,7 +84,7 @@ type of ANY (one or more) or ALL. The following filters are supported:
 -   `REGEX_ALL`
 
 For example filters, see
-`Events <events-reference-label>`{.interpreted-text role="ref"}.
+[Events](#events-reference-label).
 
 ## Event Protobuf Message
 

--- a/docs/core/1.1/app_developers_guide/kubernetes.md
+++ b/docs/core/1.1/app_developers_guide/kubernetes.md
@@ -55,8 +55,7 @@ is running a `validator`{.interpreted-text role="term"}, a
 `REST API`{.interpreted-text role="term"}, and three
 `transaction processors<transaction processor>`{.interpreted-text
 role="term"}. This environment uses
-`dev mode consensus <dynamic-consensus-label>`{.interpreted-text
-role="ref"} and
+[dev mode consensus](#dynamic-consensus-label) and
 `serial transaction processing <../architecture/scheduling>`{.interpreted-text
 role="doc"}.
 
@@ -196,8 +195,7 @@ This file defines the process for constructing a one-node Sawtooth
 environment with following containers:
 
 -   A single validator using
-    `dev mode consensus <dynamic-consensus-label>`{.interpreted-text
-    role="ref"}
+    [dev mode consensus](#dynamic-consensus-label)
 -   A REST API connected to the validator
 -   The Settings transaction processor (`sawtooth-settings`)
 -   The IntegerKey transaction processor (`intkey-tp-python`)

--- a/docs/core/1.1/architecture/scheduling.md
+++ b/docs/core/1.1/architecture/scheduling.md
@@ -39,10 +39,8 @@ transaction families may implement the appropriate business logic.
 The validator has two major components that use schedulers to calculate
 state changes and the resulting Merkle hashes based on transaction
 processing: the
-`Chain Controller <journal-chain-controller-label>`{.interpreted-text
-role="ref"} and the
-`Block Publisher <journal-block-publisher-label>`{.interpreted-text
-role="ref"}. These two components pass a scheduler to the Executor.
+[Chain Controller](#journal-chain-controller-label) and the
+[Block Publisher](#journal-block-publisher-label). These two components pass a scheduler to the Executor.
 While the validator contains only a single Chain Controller, a single
 Block Publisher, and a single Executor, there are numerous instances of
 schedulers that are dynamically created as needed.

--- a/docs/core/1.2/app_developers_guide/docker.md
+++ b/docs/core/1.2/app_developers_guide/docker.md
@@ -30,8 +30,7 @@ implements your application\'s business logic.
 This Docker environment is a single Sawtooth node that is running a
 validator, a REST API, the Devmode consensus engine, and three
 transaction processors. The environment uses
-`Devmode consensus <dynamic-consensus-label>`{.interpreted-text
-role="ref"} and
+[Devmode consensus](#dynamic-consensus-label) and
 `parallel transaction processing <../architecture/scheduling>`{.interpreted-text
 role="doc"}.
 

--- a/docs/core/1.2/app_developers_guide/kubernetes.md
+++ b/docs/core/1.2/app_developers_guide/kubernetes.md
@@ -52,8 +52,7 @@ supported VM hypervisor, such as VirtualBox.
 This Kubernetes environment is a single Sawtooth node that is running a
 validator, a REST API, the Devmode consensus engine, and three
 transaction processors. The environment uses
-`Devmode consensus <dynamic-consensus-label>`{.interpreted-text
-role="ref"} and
+[Devmode consensus](#dynamic-consensus-label) and
 `parallel transaction processing <../architecture/scheduling>`{.interpreted-text
 role="doc"}.
 

--- a/docs/core/1.2/app_developers_guide/ubuntu.md
+++ b/docs/core/1.2/app_developers_guide/ubuntu.md
@@ -35,8 +35,7 @@ implements your application\'s business logic.
 This Ubuntu environment is a single Sawtooth node that is running a
 validator, a REST API, the Devmode consensus engine, and three
 transaction processors. The environment uses
-`Devmode consensus <dynamic-consensus-label>`{.interpreted-text
-role="ref"} and
+[Devmode consensus](#dynamic-consensus-label) and
 `parallel transaction processing <../architecture/scheduling>`{.interpreted-text
 role="doc"}.
 

--- a/docs/core/1.2/architecture/scheduling.md
+++ b/docs/core/1.2/architecture/scheduling.md
@@ -39,10 +39,8 @@ transaction families may implement the appropriate business logic.
 The validator has two major components that use schedulers to calculate
 state changes and the resulting Merkle hashes based on transaction
 processing: the
-`Chain Controller <journal-chain-controller-label>`{.interpreted-text
-role="ref"} and the
-`Block Publisher <journal-block-publisher-label>`{.interpreted-text
-role="ref"}. These two components pass a scheduler to the Executor.
+[Chain Controller](#journal-chain-controller-label) and the
+[Block Publisher](#journal-block-publisher-label). These two components pass a scheduler to the Executor.
 While the validator contains only a single Chain Controller, a single
 Block Publisher, and a single Executor, there are numerous instances of
 schedulers that are dynamically created as needed.

--- a/docs/seth/0.2/dapps.md
+++ b/docs/seth/0.2/dapps.md
@@ -29,7 +29,7 @@ complete understanding of the
 role="doc"}. Instead, Seth comes with a web server that implements much
 of the [Ethereum JSON-RPC
 API](https://github.com/ethereum/wiki/wiki/JSON-RPC), the
-`seth-rpc <seth-rpc-reference-label>`{.interpreted-text role="ref"}
+[seth-rpc](#seth-rpc-reference-label)
 server. This interface provides a much higher level interface for
 developing Seth applications and is the recommended interface.
 

--- a/docs/seth/0.2/introduction.md
+++ b/docs/seth/0.2/introduction.md
@@ -17,12 +17,10 @@ API](https://github.com/ethereum/wiki/wiki/JSON-RPC).
 
 Seth is composed of three components:
 
-1.  The `seth <seth-cli-reference-label>`{.interpreted-text role="ref"}
+1.  The [seth](#seth-cli-reference-label)
     client
-2.  The `seth-tp <seth-tp-reference-label>`{.interpreted-text
-    role="ref"} transaction processor
-3.  The `seth-rpc <seth-rpc-reference-label>`{.interpreted-text
-    role="ref"} server
+2.  The [seth-tp](#seth-tp-reference-label) transaction processor
+3.  The [seth-rpc](#seth-rpc-reference-label) server
 
 The `seth` client is the user-facing CLI tool for interacting with a
 Sawtooth network that has Seth deployed on it. The `seth-tp` transaction


### PR DESCRIPTION
This replaces:
```
    `(.*?)\s+<(.*?)>`{.interpreted-text\s+role="ref"}
```
with
```
    [\1](#\2)
```