### PR TITLE
fix to working rest api url in guides

### DIFF
--- a/docs/1.1/app_developers_guide/intro_xo_transaction_family.md
+++ b/docs/1.1/app_developers_guide/intro_xo_transaction_family.md
@@ -99,7 +99,7 @@ client submits to the validator via the REST API.
     > demo application environment when creating a new game:
     >
     > ```
-    > $ xo create my-game --username jack --url http://rest-api:8008
+    > $ xo create my-game --username jack --url http://rest-api-0:8008
     > ```
 
 ### Step 2. Ubuntu only: Start the XO Transaction Processor

--- a/docs/1.2/app_developers_guide/installing_sawtooth.md
+++ b/docs/1.2/app_developers_guide/installing_sawtooth.md
@@ -236,7 +236,7 @@ should be run in the terminal window for the client container.
     from the client container, run this `curl` command:
 
     ``` console
-    root@client# curl http://rest-api:8008/blocks
+    root@client# curl http://rest-api-0:8008/blocks
     ```
 
 2.  To check connectivity from the host computer, open a new terminal
@@ -310,7 +310,7 @@ testing purposes.
 2.  Use `intkey load` to submit the batches to the validator.
 
     ``` console
-    root@client# intkey load -f batches.intkey --url http://rest-api:8008
+    root@client# intkey load -f batches.intkey --url http://rest-api-0:8008
     batches: 11 batch/sec: 141.7800162868952
     ```
 
@@ -361,7 +361,7 @@ transactions, you could use `sawtooth batch submit` to submit them.
 2.  Submit the batch file with `sawtooth batch submit`:
 
     ``` console
-    root@client# sawtooth batch submit -f batches.intkey --url http://rest-api:8008
+    root@client# sawtooth batch submit -f batches.intkey --url http://rest-api-0:8008
     batches: 11,  batch/sec: 216.80369536716367
     ```
 
@@ -374,7 +374,7 @@ stored on the blockchain.
     state.
 
     > ``` console
-    > root@client# sawtooth block list --url http://rest-api:8008
+    > root@client# sawtooth block list --url http://rest-api-0:8008
     > ```
     >
     > The output shows the block number and block ID, as in this
@@ -401,7 +401,7 @@ stored on the blockchain.
     the following command:
 
     ``` console
-    root@client# sawtooth block show --url http://rest-api:8008 {BLOCK_ID}
+    root@client# sawtooth block show --url http://rest-api-0:8008 {BLOCK_ID}
     ```
 
     The output of this command can be quite long, because it includes
@@ -441,7 +441,7 @@ State]({% link docs/1.2/architecture/global_state.md%}).
 1.  Use `sawtooth state list` to list the nodes (addresses) in state:
 
     ``` console
-    root@client# sawtooth state list --url http://rest-api:8008
+    root@client# sawtooth state list --url http://rest-api-0:8008
     ```
 
     The output will be similar to this truncated example:
@@ -463,7 +463,7 @@ State]({% link docs/1.2/architecture/global_state.md%}).
     `{STATE_ADDRESS}` in the following command:
 
     ``` console
-    root@client# sawtooth state show --url http://rest-api:8008 {STATE_ADDRESS}
+    root@client# sawtooth state show --url http://rest-api-0:8008 {STATE_ADDRESS}
     ```
 
     The output shows the bytes stored at that address and the block ID

--- a/docs/1.2/app_developers_guide/intro_xo_transaction_family.md
+++ b/docs/1.2/app_developers_guide/intro_xo_transaction_family.md
@@ -101,11 +101,11 @@ argument to each `xo` command in this procedure.
     >
     >
     > In the Docker environment, the REST API is at
-    > `http://rest-api:8008`. You must add `--url http://rest-api:8008` to
+    > `http://rest-api-0:8008`. You must add `--url http://rest-api-0:8008` to
     > all `xo` commands in this procedure. For example:
     >
     > ``` console
-    > $ xo create my-game --username jack --url http://rest-api:8008
+    > $ xo create my-game --username jack --url http://rest-api-0:8008
     > ```
 
 -   Kubernetes: See [Confirm Connectivity to the REST API (for

--- a/docs/1.2/architecture/events_and_transactions_receipts.md
+++ b/docs/1.2/architecture/events_and_transactions_receipts.md
@@ -378,7 +378,7 @@ message ClientReceiptGetResponse {
 ```
 
 To request a transaction receipt from the REST API, pass the transaction
-ID in the form `http://rest-api:8008/receipts/?id=TRANSACTION-ID` where
+ID in the form `http://rest-api-0:8008/receipts/?id=TRANSACTION-ID` where
 `TRANSACTION-ID` is your 128-character transaction ID. Use
 `localhost:8008` if the Validator is running on Ubuntu instead of
 Docker.

--- a/docs/core/1.0/app_developers_guide/docker.md
+++ b/docs/core/1.0/app_developers_guide/docker.md
@@ -208,7 +208,7 @@ To confirm that a validator is running and reachable from the client
 container, run this `curl` command as root:
 
 ``` console
-root@75b380886502:/# curl http://rest-api:8008/blocks
+root@75b380886502:/# curl http://rest-api-0:8008/blocks
 ```
 
 To check connectivity from the host computer, open a new terminal window
@@ -264,7 +264,7 @@ Run the following commands from the client container:
 
 ``` console
 $ intkey create_batch --count 10 --key-count 5
-$ intkey load -f batches.intkey -U http://rest-api:8008
+$ intkey load -f batches.intkey -U http://rest-api-0:8008
 ```
 
 The terminal window in which you ran the `docker-compose` command will
@@ -296,7 +296,7 @@ For example, you can submit the transactions in the file
 `batches.intkey` as generated above with this command:
 
 ``` console
-$ sawtooth batch submit -f batches.intkey --url http://rest-api:8008
+$ sawtooth batch submit -f batches.intkey --url http://rest-api-0:8008
 ```
 
 ## Viewing the Block Chain
@@ -320,7 +320,7 @@ Enter the command `sawtooth block list` to view the blocks stored by the
 state:
 
 ``` console
-$ sawtooth block list --url http://rest-api:8008
+$ sawtooth block list --url http://rest-api-0:8008
 ```
 
 The output of the command will be similar to this:
@@ -338,7 +338,7 @@ id of a block you want to get more info about, then paste it in place of
 `{BLOCK_ID}` in the following `sawtooth block show` command:
 
 ``` console
-$ sawtooth block show --url http://rest-api:8008 {BLOCK_ID}
+$ sawtooth block show --url http://rest-api-0:8008 {BLOCK_ID}
 ```
 
 The output of this command includes all data stored under that block,
@@ -389,7 +389,7 @@ Use the command `sawtooth state list` to list the nodes in the Merkle
 tree:
 
 ``` console
-$ sawtooth state list --url http://rest-api:8008
+$ sawtooth state list --url http://rest-api-0:8008
 ```
 
 The output of the command will be similar to this truncated list:
@@ -412,7 +412,7 @@ address you want to view, then paste it in place of `{STATE_ADDRESS}` in
 the following `sawtooth state show` command:
 
 ``` console
-$ sawtooth state show --url http://rest-api:8008 {STATE_ADDRESS}
+$ sawtooth state show --url http://rest-api-0:8008 {STATE_ADDRESS}
 ```
 
 The output of the command will include both the bytes stored at that
@@ -433,7 +433,7 @@ host. Enter the following command from the terminal window for the
 client container:
 
 ``` console
-$ curl http://rest-api:8008/blocks
+$ curl http://rest-api-0:8008/blocks
 ```
 
 ## From the Host Operating System
@@ -645,10 +645,10 @@ Then run the following command from the validator container:
 
 ``` console
 $ sawset proposal create \
-  --url http://rest-api:8008 \
+  --url http://rest-api-0:8008 \
   --key /root/.sawtooth/keys/my_key.priv \
   sawtooth.validator.transaction_families='[{"family": "intkey", "version": "1.0"}, {"family":"sawtooth_settings", "version":"1.0"}]'
-$ sawtooth settings list --url http://rest-api:8008
+$ sawtooth settings list --url http://rest-api-0:8008
 ```
 
 A TP_PROCESS_REQUEST message appears in the logging output of the

--- a/docs/core/1.1/app_developers_guide/docker.md
+++ b/docs/core/1.1/app_developers_guide/docker.md
@@ -227,7 +227,7 @@ more information.
     from the client container, run this `curl` command:
 
     ``` console
-    root@client# curl http://rest-api:8008/blocks
+    root@client# curl http://rest-api-0:8008/blocks
     ```
 
 2.  To check connectivity from the host computer, open a new terminal
@@ -305,7 +305,7 @@ testing purposes.
 2.  Use `intkey load` to submit the batches to the validator.
 
     ``` console
-    root@client# intkey load -f batches.intkey --url http://rest-api:8008
+    root@client# intkey load -f batches.intkey --url http://rest-api-0:8008
     batches: 11 batch/sec: 141.7800162868952
     ```
 
@@ -356,7 +356,7 @@ transactions, you could use `sawtooth batch submit` to submit them.
 2.  Submit the batch file with `sawtooth batch submit`:
 
     ``` console
-    root@client# sawtooth batch submit -f batches.intkey --url http://rest-api:8008
+    root@client# sawtooth batch submit -f batches.intkey --url http://rest-api-0:8008
     batches: 11,  batch/sec: 216.80369536716367
     ```
 
@@ -369,7 +369,7 @@ stored on the blockchain.
     state.
 
     > ``` console
-    > root@client# sawtooth block list --url http://rest-api:8008
+    > root@client# sawtooth block list --url http://rest-api-0:8008
     > ```
     >
     > The output shows the block number and block ID, as in this
@@ -396,7 +396,7 @@ stored on the blockchain.
     the following command:
 
     ``` console
-    root@client# sawtooth block show --url http://rest-api:8008 {BLOCK_ID}
+    root@client# sawtooth block show --url http://rest-api-0:8008 {BLOCK_ID}
     ```
 
     The output of this command can be quite long, because it includes
@@ -437,7 +437,7 @@ role="term"}; for more information, see
 1.  Use `sawtooth state list` to list the nodes (addresses) in state:
 
     ``` console
-    root@client# sawtooth state list --url http://rest-api:8008
+    root@client# sawtooth state list --url http://rest-api-0:8008
     ```
 
     The output will be similar to this truncated example:
@@ -459,7 +459,7 @@ role="term"}; for more information, see
     `{STATE_ADDRESS}` in the following command:
 
     ``` console
-    root@client# sawtooth state show --url http://rest-api:8008 {STATE_ADDRESS}
+    root@client# sawtooth state show --url http://rest-api-0:8008 {STATE_ADDRESS}
     ```
 
     The output shows the bytes stored at that address and the block ID

--- a/docs/core/1.1/architecture/events_and_transactions_receipts.md
+++ b/docs/core/1.1/architecture/events_and_transactions_receipts.md
@@ -379,7 +379,7 @@ message ClientReceiptGetResponse {
 ```
 
 To request a transaction receipt from the REST API, pass the transaction
-ID in the form `http://rest-api:8008/receipts/?id=TRANSACTION-ID` where
+ID in the form `http://rest-api-0:8008/receipts/?id=TRANSACTION-ID` where
 `TRANSACTION-ID` is your 128-character transaction ID. Use
 `localhost:8008` if the Validator is running on Ubuntu instead of
 Docker.

--- a/docs/core/1.1/sysadmin_guide/testing_sawtooth.md
+++ b/docs/core/1.1/sysadmin_guide/testing_sawtooth.md
@@ -64,7 +64,7 @@ functionality.
             "data": [
             "tcp://validator-1:8800",
           ],
-          "link": "http://rest-api:8008/peers"
+          "link": "http://rest-api-0:8008/peers"
         }
         ```
 

--- a/faq/rest.md
+++ b/faq/rest.md
@@ -36,7 +36,7 @@ curl http://localhost:8008/state
 From the Client Docker container, access from rest-api. For example:
 
 ``` sh
-curl http://rest-api:8008/state
+curl http://rest-api-0:8008/state
 ```
 
 These are the supported REST API commands:

--- a/faq/sawtooth.md
+++ b/faq/sawtooth.md
@@ -539,7 +539,7 @@ commands in a `Dockerfile` as follows:
     `Dockerfile` for each container
 -   Install your application\'s transaction processor and client.
 -   Make sure your client app connects to the REST API at
-    `http://localhost:8008` instead of `http://rest-api:8008`
+    `http://localhost:8008` instead of `http://rest-api-0:8008`
 -   Make sure your transaction processor connects to
     `tcp://localhost:4004` instead of `tcp://validator:4004`
 -   Start the Validator, REST API, and Settings TP:

--- a/faq/validator.md
+++ b/faq/validator.md
@@ -62,7 +62,7 @@ This verifies the REST API is available.
 From the Client Docker container run this:
 
 ``` sh
-curl http://rest-api:8008/blocks
+curl http://rest-api-0:8008/blocks
 ```
 
 You should see a JSON response similar to this:


### PR DESCRIPTION
Intends to fix steps in the various guides where the REST API URL link provided will return an error.