### PR TITLE
link to 1-2 PoET yaml in creating sawtooth network guide

### DIFF
--- a/docs/1.2/app_developers_guide/creating_sawtooth_network.md
+++ b/docs/1.2/app_developers_guide/creating_sawtooth_network.md
@@ -199,9 +199,9 @@ access those settings when they join the network.
 Download the Docker Compose file for a multiple-node network.
 
 -   For PBFT, download
-    [sawtooth-default-pbft.yaml](https://github.com/hyperledger/sawtooth-core/blob/main/docker/compose/sawtooth-default-pbft.yaml)
+    [sawtooth-default-pbft.yaml](https://github.com/hyperledger/sawtooth-core/blob/1-2/docker/compose/sawtooth-default-pbft.yaml)
 -   For PoET, download
-    [sawtooth-default-poet.yaml](https://github.com/hyperledger/sawtooth-core/blob/main/docker/compose/sawtooth-default-poet.yaml)
+    [sawtooth-default-poet.yaml](https://github.com/hyperledger/sawtooth-core/blob/1-2/docker/compose/sawtooth-default-poet.yaml)
 
 ### Step 2: Start the Sawtooth Network
 

--- a/docs/1.2/app_developers_guide/installing_sawtooth.md
+++ b/docs/1.2/app_developers_guide/installing_sawtooth.md
@@ -804,7 +804,7 @@ Minikube](https://kubernetes.io/docs/setup/minikube/).
 
 Download the Kubernetes configuration file for a single-node
 environment:
-[sawtooth-kubernetes-default.yaml](https://github.com/hyperledger/sawtooth-core/blob/main/docker/kubernetes/sawtooth-kubernetes-default.yaml).
+[sawtooth-kubernetes-default.yaml](https://github.com/hyperledger/sawtooth-core/blob/1-2/docker/kubernetes/sawtooth-kubernetes-default.yaml).
 
 This file defines the process for constructing a one-node Sawtooth
 environment with following containers:


### PR DESCRIPTION
This fixes a number of issues reported via Discord with the usability of PoET consensus in the [Creating a Sawtooth Network](https://sawtooth.hyperledger.org/docs/1.2/app_developers_guide/creating_sawtooth_network.html) by linking to the `1-2` branch docker compose yaml file, which uses `chime` images.  

---
[SAW-16](https://blockchaintp.atlassian.net/browse/SAW-16)

Signed-off-by: Joseph Livesey [joseph.livesey@btp.works](mailto:joseph.livesey@btp.works)