### PR TITLE
Mention PoET alongside PBFT in v1.2 introduction.

### DIFF
--- a/docs/1.2/index.md
+++ b/docs/1.2/index.md
@@ -327,6 +327,8 @@ ledger.
 >     -   Source files for this documentation
 > -   [Sawtooth PBFT](https://github.com/hyperledger/sawtooth-pbft): Use
 >     PBFT consensus with Sawtooth
+> -   [Sawtooth PoET](https://github.com/hyperledger/sawtooth-poet): Use
+>     PoET consensus with Sawtooth
 > -   [Sawtooth Sabre](https://github.com/hyperledger/sawtooth-sabre):
 >     Run on-chain smart contracts executed in a WebAssembly virtual
 >     machine


### PR DESCRIPTION
@suchapalaver noticed that it seemed odd to mention PBFT but not PoET in the introduction's enumeration of Sawtooth software.