### PR TITLE
Run merge github action on push of main and workflow_dispatch

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -2,8 +2,8 @@ name: Merge
 
 on:
   push:
-  schedule:
-    - cron: "30 8 * * *"
+    branches: [ main ]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This removes the cron entry (no need to run this via cron). Also adds restriction to only publish on main push, which is usually triggered during a OR merge. And finally, add workflow_dispatch so we can run the job manually in the github UI.